### PR TITLE
Add least squares approximation

### DIFF
--- a/examples/interpolation/least_squares_2d.jl
+++ b/examples/interpolation/least_squares_2d.jl
@@ -1,0 +1,28 @@
+using KernelInterpolation
+using Plots
+
+# interpolate Franke function
+function f(x)
+    0.75 * exp(-0.25 * ((9 * x[1] - 2)^2 + (9 * x[2] - 2)^2)) +
+    0.75 * exp(-(9 * x[1] + 1)^2 / 49 - (9 * x[2] + 1) / 10) +
+    0.5 * exp(-0.25 * ((9 * x[1] - 7)^2 + (9 * x[2] - 3)^2)) -
+    0.2 * exp(-(9 * x[1] - 4)^2 - (9 * x[2] - 7)^2)
+end
+
+n = 1089
+nodeset = random_hypercube(n; dim = 2)
+values = f.(nodeset) .+ 0.03 * randn(n)
+M = 81
+centers = random_hypercube(M; dim = 2)
+
+kernel = ThinPlateSplineKernel{dim(nodeset)}()
+ls = interpolate(nodeset, centers, values, kernel)
+itp = interpolate(nodeset, values, kernel)
+
+N = 40
+many_nodes = homogeneous_hypercube(N; dim = 2)
+
+p1 = plot(many_nodes, ls, st = :surface, training_nodes = false)
+p2 = plot(many_nodes, itp, st = :surface, training_nodes = false)
+
+plot(p1, p2, layout = (2, 1))

--- a/src/discretization.jl
+++ b/src/discretization.jl
@@ -53,7 +53,8 @@ function solve_stationary(spatial_discretization::SpatialDiscretization{Dim, Rea
     # Do not support additional polynomial basis for now
     xx = polyvars(Dim)
     ps = monomials(xx, 0:-1)
-    return Interpolation(kernel, merge(nodeset_inner, nodeset_boundary), c, system_matrix,
+    nodeset = merge(nodeset_inner, nodeset_boundary)
+    return Interpolation(kernel, nodeset, nodeset, c, system_matrix,
                          ps, xx)
 end
 

--- a/src/visualization.jl
+++ b/src/visualization.jl
@@ -106,13 +106,13 @@ end
     elseif dim(nodeset) == 2
         if training_nodes
             @series begin
-                x = values_along_dim(itp.nodeset, 1)
-                y = values_along_dim(itp.nodeset, 2)
+                x = values_along_dim(itp.centers, 1)
+                y = values_along_dim(itp.centers, 2)
                 seriestype := :scatter
                 markershape --> :star
                 markersize --> 10
                 label --> "training nodes"
-                x, y, itp.(itp.nodeset)
+                x, y, itp.(itp.centers)
             end
         end
         @series begin

--- a/test/test_examples_interpolation.jl
+++ b/test/test_examples_interpolation.jl
@@ -118,3 +118,14 @@ end
     @test_include_example(joinpath(EXAMPLES_DIR, "interpolation_2d_condition.jl"),
                           ns=5:10)
 end
+
+@testitem "least_squares_2d.jl" setup=[
+    Setup,
+    AdditionalImports,
+    InterpolationExamples
+] begin
+    @test_include_example(joinpath(EXAMPLES_DIR, "least_squares_2d.jl"),
+                          l2=1.2759520194191292, linf=0.19486087346749836,
+                          l2_ls=0.5375130503454387, linf_ls=0.06810374254243684,
+                          interpolation_test=false, least_square_test=true)
+end

--- a/test/test_unit.jl
+++ b/test/test_unit.jl
@@ -675,8 +675,36 @@ end
     @test length(polynomial_basis(itp)) ==
           binomial(order(itp) - 1 + dim(nodes), dim(nodes))
     @test system_matrix(itp) isa Symmetric
+    @test size(system_matrix(itp)) == (7, 7)
     @test isapprox(itp([0.5, 0.5]), 1.0)
     @test isapprox(kernel_norm(itp), 0.0)
+
+    # Least squares approximation
+    centers = NodeSet([0.0 0.0
+                       1.0 0.0
+                       0.0 1.0])
+    itp = @test_nowarn interpolate(nodes, centers, ff, kernel)
+    expected_coefficients = [
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        1.0,
+        1.0]
+    coeffs = coefficients(itp)
+    @test length(coeffs) == length(expected_coefficients)
+    for i in eachindex(coeffs)
+        @test isapprox(coeffs[i], expected_coefficients[i], atol = 1e-15)
+    end
+    @test order(itp) == order(kernel)
+    @test length(kernel_coefficients(itp)) == length(itp.centers)
+    @test length(polynomial_coefficients(itp)) == order(itp) + 1
+    @test length(polynomial_basis(itp)) ==
+          binomial(order(itp) - 1 + dim(nodes), dim(nodes))
+    @test system_matrix(itp) isa Matrix
+    @test size(system_matrix(itp)) == (7, 6)
+    @test isapprox(itp([0.5, 0.5]), 1.0)
+    @test isapprox(kernel_norm(itp), 0.0, atol = 1e-15)
 
     # 1D interpolation and evaluation
     nodes = NodeSet(LinRange(0.0, 1.0, 10))


### PR DESCRIPTION
Allow to `interpolate`, where `centers` of basis functions differ from the data sites to perform a least squares approximation.

TODO:
- [x] add example
- [x] fix functions using `nodeset(itp)`. Need `nodeset.centers` now?!
- [x] double-check with polynomials
- [ ] double-check for solving PDEs with collocation (stationary and time-dependent): postponed for now
- [x] add test
- [x] docstring
- [ ] docs (tutorial?): postponed (will be together with regularization)