### PR TITLE
Add possibility to use different node set for centers to solve PDEs

### DIFF
--- a/examples/PDEs/anisotropic_elliptic_2d_basic.jl
+++ b/examples/PDEs/anisotropic_elliptic_2d_basic.jl
@@ -23,11 +23,12 @@ n = 10
 nodeset_inner = homogeneous_hypercube(n, (0.1, 0.1), (0.9, 0.9); dim = 2)
 n_boundary = 3
 nodeset_boundary = homogeneous_hypercube_boundary(n_boundary; dim = 2)
+centers = homogeneous_hypercube(8; dim = 2)
 # Dirichlet boundary condition (here taken from analytical solution)
 g(x) = u(x, pde)
 
-kernel = WendlandKernel{2}(3, shape_parameter = 0.8)
-sd = SpatialDiscretization(pde, nodeset_inner, g, nodeset_boundary, kernel)
+kernel = WendlandKernel{2}(3, shape_parameter = 0.4)
+sd = SpatialDiscretization(pde, nodeset_inner, g, nodeset_boundary, centers, kernel)
 itp = solve_stationary(sd)
 
 many_nodes = homogeneous_hypercube(20; dim = 2)

--- a/src/discretization.jl
+++ b/src/discretization.jl
@@ -128,9 +128,8 @@ function Semidiscretization(equations, nodeset_inner::NodeSet{Dim, RealT},
                             initial_condition,
                             kernel = GaussKernel{Dim}()) where {Dim, RealT}
     return Semidiscretization(equations, nodeset_inner, boundary_condition,
-                              nodeset_boundary,
-                              initial_condition, merge(nodeset_inner, nodeset_boundary),
-                              kernel)
+                              nodeset_boundary, merge(nodeset_inner, nodeset_boundary),
+                              initial_condition, kernel)
 end
 
 function Base.show(io::IO, semi::Semidiscretization)

--- a/src/discretization.jl
+++ b/src/discretization.jl
@@ -1,9 +1,11 @@
 """
-    SpatialDiscretization(equations, nodeset_inner, boundary_condition, nodeset_boundary)
+    SpatialDiscretization(equations, nodeset_inner, boundary_condition, nodeset_boundary,
+                          [centers,] kernel = GaussKernel{dim(nodeset_inner)}())
 
 Spatial discretization of a partial differential equation with Dirichlet boundary conditions.
 The `nodeset_inner` are the nodes in the domain and `nodeset_boundary` are the nodes on the boundary. The `boundary_condition`
-is a function describing the Dirichlet boundary conditions.
+is a function describing the Dirichlet boundary conditions. The `centers` are the centers of the kernel functions. By default,
+`centers` is set to `merge(nodeset_inner, nodeset_boundary)`. Otherwise, a least squares problem is solved.
 
 See also [`Semidiscretization`](@ref), [`solve_stationary`](@ref).
 """
@@ -13,16 +15,30 @@ struct SpatialDiscretization{Dim, RealT, Equations, BoundaryCondition,
     nodeset_inner::NodeSet{Dim, RealT}
     boundary_condition::BoundaryCondition
     nodeset_boundary::NodeSet{Dim, RealT}
+    centers::NodeSet{Dim, RealT}
     kernel::Kernel
 
-    function SpatialDiscretization(equations, nodeset_inner, boundary_condition,
-                                   nodeset_boundary,
-                                   kernel = GaussKernel{dim(nodeset_inner)}())
-        new{dim(nodeset_inner), eltype(nodeset_inner), typeof(equations),
-            typeof(boundary_condition), typeof(kernel)}(equations,
-                                                        nodeset_inner, boundary_condition,
-                                                        nodeset_boundary, kernel)
+    function SpatialDiscretization(equations, nodeset_inner::NodeSet{Dim, RealT},
+                                   boundary_condition,
+                                   nodeset_boundary::NodeSet{Dim, RealT},
+                                   centers::NodeSet{Dim, RealT},
+                                   kernel = GaussKernel{Dim}()) where {Dim,
+                                                                       RealT}
+        new{Dim, RealT, typeof(equations), typeof(boundary_condition),
+            typeof(kernel)}(equations, nodeset_inner,
+                            boundary_condition, nodeset_boundary,
+                            centers, kernel)
     end
+end
+
+function SpatialDiscretization(equations, nodeset_inner::NodeSet{Dim, RealT},
+                               boundary_condition,
+                               nodeset_boundary::NodeSet{Dim, RealT},
+                               kernel = GaussKernel{Dim}()) where {Dim, RealT
+                                                                   }
+    return SpatialDiscretization(equations, nodeset_inner, boundary_condition,
+                                 nodeset_boundary,
+                                 merge(nodeset_inner, nodeset_boundary), kernel)
 end
 
 function Base.show(io::IO, sd::SpatialDiscretization)
@@ -44,9 +60,10 @@ function solve_stationary(spatial_discretization::SpatialDiscretization{Dim, Rea
                                                                                             Dim,
                                                                                             RealT
                                                                                             }
-    @unpack equations, nodeset_inner, boundary_condition, nodeset_boundary, kernel = spatial_discretization
+    @unpack equations, nodeset_inner, boundary_condition, nodeset_boundary, centers, kernel = spatial_discretization
 
-    system_matrix = pde_boundary_matrix(equations, nodeset_inner, nodeset_boundary, kernel)
+    system_matrix = pde_boundary_matrix(equations, nodeset_inner, nodeset_boundary, centers,
+                                        kernel)
     b = [rhs(nodeset_inner, equations); boundary_condition.(nodeset_boundary)]
     c = system_matrix \ b
 
@@ -54,17 +71,20 @@ function solve_stationary(spatial_discretization::SpatialDiscretization{Dim, Rea
     xx = polyvars(Dim)
     ps = monomials(xx, 0:-1)
     nodeset = merge(nodeset_inner, nodeset_boundary)
-    return Interpolation(kernel, nodeset, nodeset, c, system_matrix,
+    return Interpolation(kernel, nodeset, centers, c, system_matrix,
                          ps, xx)
 end
 
 """
     Semidiscretization(spatial_discretization, initial_condition)
-    Semidiscretization(equations, nodeset_inner, boundary_condition, nodeset_boundary, initial_condition, kernel = GaussKernel{dim(nodeset_inner)}())
+    Semidiscretization(equations, nodeset_inner, boundary_condition, nodeset_boundary, [centers,]
+                       initial_condition, kernel = GaussKernel{dim(nodeset_inner)}())
 
 Semidiscretization of a partial differential equation with Dirichlet boundary conditions and initial condition `initial_condition`. The `boundary_condition` function
 can be time- and space-dependent. The `initial_condition` function is time- and space-dependent to be able to reuse it as analytical solution if available. If no
-analytical solution is available, the time variable can be ignored in the `initial_condition` function.
+analytical solution is available, the time variable can be ignored in the `initial_condition` function. The `centers` are the centers of the kernel functions. By default,
+`centers` is set to `merge(nodeset_inner, nodeset_boundary)`. Note that `centers` needs to have the center number of nodes as the number of nodes in the domain and on the boundary
+because OrdinaryDiffEq.jl does not support DAEs with rectangular mass matrices.
 
 See also [`SpatialDiscretization`](@ref), [`semidiscretize`](@ref).
 """
@@ -74,16 +94,17 @@ struct Semidiscretization{InitialCondition, Cache}
     cache::Cache
 end
 
-function Semidiscretization(spatial_discretization, initial_condition)
-    @unpack equations, nodeset_inner, boundary_condition, nodeset_boundary, kernel = spatial_discretization
-    nodeset = merge(nodeset_inner, nodeset_boundary)
-    k_matrix_inner = kernel_matrix(nodeset_inner, nodeset, kernel)
-    k_matrix_boundary = kernel_matrix(nodeset_boundary, nodeset, kernel)
+function Semidiscretization(spatial_discretization::SpatialDiscretization,
+                            initial_condition)
+    @unpack equations, nodeset_inner, boundary_condition, nodeset_boundary, centers, kernel = spatial_discretization
+    @assert length(centers)==length(nodeset_inner) + length(nodeset_boundary) "The number of centers must be equal to the number of inner and boundary nodes."
+    k_matrix_inner = kernel_matrix(nodeset_inner, centers, kernel)
+    k_matrix_boundary = kernel_matrix(nodeset_boundary, centers, kernel)
     # whole kernel matrix is not needed for rhs, but for initial condition
     k_matrix = [k_matrix_inner
                 k_matrix_boundary]
-    pdeb_matrix = pde_boundary_matrix(equations, nodeset_inner, nodeset_boundary, kernel)
-
+    pdeb_matrix = pde_boundary_matrix(equations, nodeset_inner, nodeset_boundary, centers,
+                                      kernel)
     m_matrix = [k_matrix_inner
                 zeros(eltype(k_matrix_inner), size(k_matrix_boundary)...)]
     cache = (; kernel_matrix = k_matrix, mass_matrix = m_matrix,
@@ -93,11 +114,23 @@ function Semidiscretization(spatial_discretization, initial_condition)
                                                                         cache)
 end
 
-function Semidiscretization(equations, nodeset_inner, boundary_condition, nodeset_boundary,
-                            initial_condition, kernel = GaussKernel{dim(nodeset_inner)}())
+function Semidiscretization(equations, nodeset_inner::NodeSet{Dim, RealT},
+                            boundary_condition, nodeset_boundary::NodeSet{Dim, RealT},
+                            centers::NodeSet{Dim, RealT}, initial_condition,
+                            kernel = GaussKernel{Dim}()) where {Dim, RealT}
     return Semidiscretization(SpatialDiscretization(equations, nodeset_inner,
                                                     boundary_condition, nodeset_boundary,
-                                                    kernel), initial_condition)
+                                                    centers, kernel), initial_condition)
+end
+
+function Semidiscretization(equations, nodeset_inner::NodeSet{Dim, RealT},
+                            boundary_condition, nodeset_boundary::NodeSet{Dim, RealT},
+                            initial_condition,
+                            kernel = GaussKernel{Dim}()) where {Dim, RealT}
+    return Semidiscretization(equations, nodeset_inner, boundary_condition,
+                              nodeset_boundary,
+                              initial_condition, merge(nodeset_inner, nodeset_boundary),
+                              kernel)
 end
 
 function Base.show(io::IO, semi::Semidiscretization)

--- a/src/interpolation.jl
+++ b/src/interpolation.jl
@@ -121,7 +121,7 @@ of known values. The exact form of ``A`` differs depending on which method is us
 system_matrix(itp::Interpolation) = itp.system_matrix
 
 @doc raw"""
-    interpolate(nodeset, centers = nodeset, values, kernel = GaussKernel{dim(nodeset)}();
+    interpolate(nodeset, [centers,] values, kernel = GaussKernel{dim(nodeset)}();
                 m = order(kernel), regularization = NoRegularization())
 
 Interpolate the `values` evaluated at the nodes in the `nodeset` to a function using the kernel `kernel`
@@ -138,6 +138,7 @@ maximum degree of `m - 1`. If `m = 0`, no polynomial is added. The additional co
 are enforced. Returns an [`Interpolation`](@ref) object.
 
 If `centers` is provided, the interpolant is a least squares approximation with the centers used for the basis.
+Otherwise, `centers` is set to `nodeset`.
 
 A regularization can be applied to the kernel matrix using the `regularization` argument, cf. [`regularize!`](@ref).
 """
@@ -281,13 +282,13 @@ end
 function (titp::TemporalInterpolation)(t)
     ode_sol = titp.ode_sol
     semi = ode_sol.prob.p
-    @unpack kernel, nodeset_inner, boundary_condition, nodeset_boundary = semi.spatial_discretization
+    @unpack kernel, nodeset_inner, boundary_condition, nodeset_boundary, centers = semi.spatial_discretization
     c = ode_sol(t)
     # Do not support additional polynomial basis for now
     xx = polyvars(dim(semi))
     ps = monomials(xx, 0:-1)
     nodeset = merge(nodeset_inner, nodeset_boundary)
-    itp = Interpolation(kernel, nodeset, nodeset, c,
+    itp = Interpolation(kernel, nodeset, centers, c,
                         semi.cache.mass_matrix, ps, xx)
     return itp
 end

--- a/src/kernel_matrices.jl
+++ b/src/kernel_matrices.jl
@@ -120,7 +120,7 @@ function pde_matrix(diff_op_or_pde, nodeset1, nodeset2, kernel)
 end
 
 @doc raw"""
-    pde_boundary_matrix(diff_op_or_pde, nodeset_inner, nodeset_boundary, kernel)
+    pde_boundary_matrix(diff_op_or_pde, nodeset_inner, nodeset_boundary, [centers,] kernel)
 
 Compute the matrix of a partial differential equation (or differential operator) with a given kernel. The matrix is defined as
 ```math
@@ -135,16 +135,21 @@ and ``\tilde A`` is the kernel matrix for the boundary nodes:
     \tilde A_{ij} = K(x_i, \xi_j),
 ```
 where ``\mathcal{L}`` is the differential operator (defined by the `equations`), ``K`` the `kernel`, ``x_i`` are the nodes
-in `nodeset_boundary` and ``\xi_j`` are the nodes in union of `nodeset_inner` and `nodeset_boundary`.
+in `nodeset_boundary` and ``\xi_j`` are the `centers`. By default, `centers` is set to `merge(nodeset_inner, nodeset_boundary)`.
 
 See also [`pde_matrix`](@ref) and [`kernel_matrix`](@ref).
 """
-function pde_boundary_matrix(diff_op_or_pde, nodeset_inner, nodeset_boundary, kernel)
-    nodeset = merge(nodeset_inner, nodeset_boundary)
-    pd_matrix = pde_matrix(diff_op_or_pde, nodeset_inner, nodeset, kernel)
-    b_matrix = kernel_matrix(nodeset_boundary, nodeset, kernel)
+function pde_boundary_matrix(diff_op_or_pde, nodeset_inner, nodeset_boundary, centers,
+                             kernel)
+    pd_matrix = pde_matrix(diff_op_or_pde, nodeset_inner, centers, kernel)
+    b_matrix = kernel_matrix(nodeset_boundary, centers, kernel)
     return [pd_matrix
             b_matrix]
+end
+
+function pde_boundary_matrix(diff_op_or_pde, nodeset_inner, nodeset_boundary, kernel)
+    pde_boundary_matrix(diff_op_or_pde, nodeset_inner, nodeset_boundary,
+                        merge(nodeset_inner, nodeset_boundary), kernel)
 end
 
 @doc raw"""

--- a/test/test_examples_pde.jl
+++ b/test/test_examples_pde.jl
@@ -9,42 +9,36 @@ end
     @test_include_example(joinpath(EXAMPLES_DIR, "poisson_2d_basic.jl"),
                           l2=0.051892875031473, linf=0.009623271947010141,
                           pde_test=true)
-    rm("out"; force = true, recursive = true)
 end
 
 @testitem "laplace_2d_annulus.jl" setup=[Setup, AdditionalImports, PDEExamples] begin
     # No analytical solution available (don't compare l2 and linf norms)
     @test_include_example(joinpath(EXAMPLES_DIR, "laplace_2d_annulus.jl"),
                           pde_test=true, atol=1e-11)
-    rm("out"; force = true, recursive = true)
 end
 
 @testitem "anisotropic_elliptic_2d_basic.jl" setup=[Setup, AdditionalImports, PDEExamples] begin
     @test_include_example(joinpath(EXAMPLES_DIR, "anisotropic_elliptic_2d_basic.jl"),
                           l2=0.3680733486177618, linf=0.09329545570900866,
                           pde_test=true)
-    rm("out"; force = true, recursive = true)
 end
 
 @testitem "heat_2d_basic.jl" setup=[Setup, AdditionalImports, PDEExamples] begin
     @test_include_example(joinpath(EXAMPLES_DIR, "heat_2d_basic.jl"),
                           l2=0.8163804581267793, linf=0.07510840007130493,
                           pde_test=true)
-    rm("out"; force = true, recursive = true)
 end
 
 @testitem "heat_2d_manufactured.jl" setup=[Setup, AdditionalImports, PDEExamples] begin
     @test_include_example(joinpath(EXAMPLES_DIR, "heat_2d_manufactured.jl"),
                           l2=0.05146343652866822, linf=0.005234201747677858,
                           pde_test=true)
-    rm("out"; force = true, recursive = true)
 end
 
 @testitem "advection_1d_basic.jl" setup=[Setup, AdditionalImports, PDEExamples] begin
     @test_include_example(joinpath(EXAMPLES_DIR, "advection_1d_basic.jl"),
                           l2=0.026436141175788297, linf=0.004194649552604207,
                           pde_test=true, atol=1e-6) # stability issues
-    rm("out"; force = true, recursive = true)
 end
 
 @testitem "advection_3d_basic.jl" setup=[Setup, AdditionalImports, PDEExamples] begin
@@ -52,7 +46,6 @@ end
         @test_include_example(joinpath(EXAMPLES_DIR, "advection_3d_basic.jl"),
                               l2=0.055338785034078526, linf=0.004385483831323006,
                               pde_test=true, tspan=(0.0, 0.1))
-        rm("out"; force = true, recursive = true)
     end
 end
 
@@ -61,5 +54,4 @@ end
                           l2=1.5864821617681693, linf=0.56470989589118,
                           pde_test=true, tspan=(0.0, 0.1),
                           atol=1e-11) # stability issues
-    rm("out"; force = true, recursive = true)
 end

--- a/test/test_examples_pde.jl
+++ b/test/test_examples_pde.jl
@@ -19,8 +19,8 @@ end
 
 @testitem "anisotropic_elliptic_2d_basic.jl" setup=[Setup, AdditionalImports, PDEExamples] begin
     @test_include_example(joinpath(EXAMPLES_DIR, "anisotropic_elliptic_2d_basic.jl"),
-                          l2=0.3680733486177618, linf=0.09329545570900866,
-                          pde_test=true)
+                          l2=0.6820834994466024, linf=0.10747754142379007,
+                          pde_test=true, least_square_test=true)
 end
 
 @testitem "heat_2d_basic.jl" setup=[Setup, AdditionalImports, PDEExamples] begin

--- a/test/test_util.jl
+++ b/test/test_util.jl
@@ -98,7 +98,7 @@ macro test_include_example(example, args...)
                 end
 
                 if !$least_square_test
-                    for (node, value) in zip(nodeset_inner, values_inner)
+                    for (node, value) in zip(nodeset_boundary, values_boundary)
                         @test isapprox(itp2(node), value, atol = $atol, rtol = $rtol)
                     end
                 end

--- a/test/test_util.jl
+++ b/test/test_util.jl
@@ -71,12 +71,14 @@ macro test_include_example(example, args...)
                 # assumes `many_nodes`, `nodes_inner` and `nodeset_boundary` are defined in the example
                 # if `u` is defined, it is used to compare the solution (analytical solution or initial condition) using the l2 and linf norms
                 if pde isa KernelInterpolation.AbstractStationaryEquation
-                    rhs_values = KernelInterpolation.rhs(nodeset_inner, pde)
-                    for i in eachindex(nodeset_inner)
-                        @test isapprox(pde(itp, nodeset_inner[i]), rhs_values[i],
-                                       atol = $atol, rtol = $rtol)
+                    if !$least_square_test
+                        rhs_values = KernelInterpolation.rhs(nodeset_inner, pde)
+                        for i in eachindex(nodeset_inner)
+                            @test isapprox(pde(itp, nodeset_inner[i]), rhs_values[i],
+                                           atol = $atol, rtol = $rtol)
+                        end
+                        values_boundary = g.(nodeset_boundary)
                     end
-                    values_boundary = g.(nodeset_boundary)
                     # Because of some namespace issues
                     itp2 = itp
 
@@ -95,8 +97,10 @@ macro test_include_example(example, args...)
                     error("Unknown PDE type")
                 end
 
-                for (node, value) in zip(nodeset_boundary, values_boundary)
-                    @test isapprox(itp2(node), value, atol = $atol, rtol = $rtol)
+                if !$least_square_test
+                    for (node, value) in zip(nodeset_inner, values_inner)
+                        @test isapprox(itp2(node), value, atol = $atol, rtol = $rtol)
+                    end
                 end
 
                 if @isdefined many_values

--- a/test/test_util.jl
+++ b/test/test_util.jl
@@ -109,6 +109,8 @@ macro test_include_example(example, args...)
             end
         end
         println("═"^100)
+        # Clean up
+        rm("out"; force = true, recursive = true)
     end
 end
 


### PR DESCRIPTION
Finalizes #93. For time-dependent PDEs the number of center nodes needs to be the same as the sum of the nodes in the interior and on the boundary because the mass matrix needs to be square.