### PR TITLE
Remove extras section in Project.toml

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -46,6 +46,3 @@ TrixiBase = "0.1.3"
 TypedPolynomials = "0.4.1"
 WriteVTK = "1.18"
 julia = "1.10"
-
-[extras]
-Meshes = "eacbb407-ea5a-433e-ab97-5258b1ca43fa"


### PR DESCRIPTION
The `[extras]` section is not needed for package extensions under julia v1.9 and higher.