### PR TITLE
Only augment with polynomials if needed

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "KernelInterpolation"
 uuid = "95686e15-3c94-4443-8f08-76d06d509f7b"
 authors = ["Joshua Lampert <joshua.lampert@uni-hamburg.de> and contributors"]
-version = "0.2.3-DEV"
+version = "0.3.0"
 
 [deps]
 DiffEqCallbacks = "459566f4-90b8-5000-8ac3-15dfb0a30def"

--- a/src/basis.jl
+++ b/src/basis.jl
@@ -82,8 +82,9 @@ already includes polynomial augmentation of degree `m` defaulting to `order(kern
     b_j(x_i) = \delta_{ij},
 ```
 
-which means that the [`kernel_matrix`](@ref) of this basis is the identity matrix making it suitable for interpolation. Since the
-basis already includes polynomials no additional polynomial augmentation is needed for interpolation with this basis.
+which means that the [`kernel_matrix`](@ref) of this basis is the identity matrix making it suitable if multiple interpolations
+with the same `centers` of the basis and the same `kernel`, but with different right-hand sides or nodesets are performed.
+Since the basis already includes polynomials no additional polynomial augmentation is needed for interpolation with this basis.
 """
 struct LagrangeBasis{Dim, RealT, Kernel, I <: AbstractInterpolation, Monomials, PolyVars} <:
        AbstractBasis

--- a/src/interpolation.jl
+++ b/src/interpolation.jl
@@ -165,7 +165,7 @@ function interpolate(basis::AbstractBasis, values::Vector{RealT},
     @assert dim(basis) == Dim
     n = length(nodeset)
     @assert length(values) == n
-    xx = polyvars(Dim)
+    xx = polyvars(Val(Dim))
     ps = monomials(xx, 0:(m - 1))
     q = length(ps)
 

--- a/src/kernel_matrices.jl
+++ b/src/kernel_matrices.jl
@@ -74,9 +74,20 @@ function interpolation_matrix(basis::AbstractBasis, ps,
     q = length(ps)
     k_matrix = kernel_matrix(basis)
     regularize!(k_matrix, regularization)
-    p_matrix = polynomial_matrix(centers(basis), ps)
-    system_matrix = [k_matrix p_matrix
-                     p_matrix' zeros(eltype(k_matrix), q, q)]
+    # We could always use the first branch, but this is more efficient
+    # for the case where we don't use polynomial augmentation (q == 0).
+    if q > 0
+        p_matrix = polynomial_matrix(centers(basis), ps)
+        system_matrix = [k_matrix p_matrix
+                         p_matrix' zeros(eltype(k_matrix), q, q)]
+    else
+        # We could also use `cholesky` here because usually `k_matrix` is
+        # symmetric positive definite, but this might not be the case if
+        # the user explicitly sets `m = 0` even though the kernel is not
+        # strictly positive definite or the matrix might be numerically not spd.
+        # TODO: Think of an interface to allow for general matrix factorizations.
+        system_matrix = k_matrix
+    end
     return Symmetric(system_matrix)
 end
 

--- a/src/util.jl
+++ b/src/util.jl
@@ -42,4 +42,12 @@ end
 # Create `d` polyvars from `TypedPolynomials.jl`, don't use `@polyvars` because of
 # https://github.com/JuliaAlgebra/TypedPolynomials.jl/issues/51, instead use the
 # workaround from there
-polyvars(d) = ntuple(i -> Variable{Symbol("x[", i, "]")}(), Val(d))
+polyvars(d) = ntuple(i -> Variable{Symbol("x[", i, "]")}(), d)
+# The function above is not type stable.
+# Therefore, we define some common special cases for performance reasons.
+polyvars(::Val{1}) = (Variable{Symbol("x[1]")}(),)
+polyvars(::Val{2}) = (Variable{Symbol("x[1]")}(), Variable{Symbol("x[2]")}())
+function polyvars(::Val{3})
+    (Variable{Symbol("x[1]")}(), Variable{Symbol("x[2]")}(),
+     Variable{Symbol("x[3]")}())
+end


### PR DESCRIPTION
This saves some time if no polynomial augmentation is performed because we don't need to concatenate the empty matrices.