### PR TITLE
Some small performance optimizations

### DIFF
--- a/src/interpolation.jl
+++ b/src/interpolation.jl
@@ -82,7 +82,7 @@ interpolant.
 
 See also [`coefficients`](@ref) and [`polynomial_coefficients`](@ref).
 """
-kernel_coefficients(itp::Interpolation) = itp.c[eachindex(centers(itp))]
+@views kernel_coefficients(itp::Interpolation) = itp.c[eachindex(centers(itp))]
 
 """
     polynomial_coefficients(itp::Interpolation)
@@ -92,7 +92,7 @@ interpolant.
 
 See also [`coefficients`](@ref) and [`kernel_coefficients`](@ref).
 """
-polynomial_coefficients(itp::Interpolation) = itp.c[(length(centers(itp)) + 1):end]
+@views polynomial_coefficients(itp::Interpolation) = itp.c[(length(centers(itp)) + 1):end]
 
 """
     polynomial_basis(itp::Interpolation)

--- a/src/kernels/radialsymmetric_kernel.jl
+++ b/src/kernels/radialsymmetric_kernel.jl
@@ -44,7 +44,7 @@ end
 
 function (kernel::RadialSymmetricKernel)(x, y)
     @assert length(x)==length(y) "x and y must have the same length"
-    return Phi(kernel, x .- y)
+    return Phi(kernel, x - y)
 end
 
 """
@@ -193,7 +193,9 @@ function Base.show(io::IO, kernel::PolyharmonicSplineKernel{Dim}) where {Dim}
 end
 
 function phi(kernel::PolyharmonicSplineKernel, r::Real)
-    if isodd(kernel.k)
+    if kernel.k == 1 # to improve performance a little bit by saving the exponentiation
+        return r
+    elseif isodd(kernel.k)
         return r^kernel.k
     else
         return isapprox(r, 0.0) ? 0.0 : r^kernel.k * log(r)


### PR DESCRIPTION
Running (see [Discourse thread](https://discourse.julialang.org/t/linear-interpolation-given-a-triangulation-in-arbitrary-dimensions/128998/6?u=joshualampert))

```julia
test_function = (x) -> sin(x[1]^2 + x[2]^2)
npoints = 1000
points = rand(2,npoints)

using KernelInterpolation

nodeset = NodeSet(transpose(points))
kernel = PolyharmonicSplineKernel{dim(nodeset)}(1)
ff = test_function.(nodeset)
itp = interpolate(nodeset, ff, kernel)
##
using BenchmarkTools
@benchmark itp(pt) setup=(pt=rand(2))

##
@benchmark begin
    info = interpolation_info(pt, $si)
    compute_simplex_interpolation(info, $values)
end setup=(pt=rand(2))
```

on main:

```julia
julia> @benchmark itp(pt) setup=(pt=rand(2))
BenchmarkTools.Trial: 10000 samples with 1 evaluation per sample.
 Range (min … max):  50.736 μs …  15.490 ms  ┊ GC (min … max):  0.00% … 99.18%
 Time  (median):     57.234 μs               ┊ GC (median):     0.00%
 Time  (mean ± σ):   71.910 μs ± 316.812 μs  ┊ GC (mean ± σ):  12.60% ±  2.96%

     ▂  █▅  ▁                                                   
  ▂▂▄█▆▇██▇███▄▃▃▃▃▂▂▂▂▂▂▂▂▂▁▂▂▁▁▂▁▁▁▂▂▂▂▂▂▂▃▃▃▃▃▃▃▃▃▃▃▃▃▂▂▂▂▂ ▃
  50.7 μs         Histogram: frequency by time         99.2 μs <

 Memory estimate: 86.27 KiB, allocs estimate: 2014.
```

this PR:

```julia
julia> @benchmark itp(pt) setup=(pt=rand(2))
BenchmarkTools.Trial: 10000 samples with 1 evaluation per sample.
 Range (min … max):  14.906 μs …  16.043 ms  ┊ GC (min … max):  0.00% … 99.59%
 Time  (median):     16.838 μs               ┊ GC (median):     0.00%
 Time  (mean ± σ):   23.739 μs ± 216.162 μs  ┊ GC (mean ± σ):  12.81% ±  1.41%

  ▂▂▆▇██▇▅▃▁▁                         ▁▁ ▁▂▃▅▄▄▄▄▃▂▂▃▃▂▂▂▂▁    ▂
  ████████████▆██▇▇██▇██▆▅▅▅▂▅▄▅▄▃▂▃▃▅███████████████████████▇ █
  14.9 μs       Histogram: log(frequency) by time      34.2 μs <

 Memory estimate: 31.45 KiB, allocs estimate: 1009.
```