### PR TITLE
Allow evaluating kernels at scalars

### DIFF
--- a/src/KernelInterpolation.jl
+++ b/src/KernelInterpolation.jl
@@ -21,7 +21,7 @@ using RecipesBase: RecipesBase, @recipe, @series
 using SciMLBase: ODEFunction, ODEProblem, ODESolution, DiscreteCallback, u_modified!
 using SimpleUnPack: @unpack
 using SpecialFunctions: besselk, loggamma
-using StaticArrays: StaticArrays, MVector, SVector
+using StaticArrays: StaticArrays, StaticVector, MVector, SVector
 using Reexport: @reexport
 using TimerOutputs: TimerOutputs, print_timer, reset_timer!
 @reexport using TrixiBase: trixi_include

--- a/src/KernelInterpolation.jl
+++ b/src/KernelInterpolation.jl
@@ -21,7 +21,7 @@ using RecipesBase: RecipesBase, @recipe, @series
 using SciMLBase: ODEFunction, ODEProblem, ODESolution, DiscreteCallback, u_modified!
 using SimpleUnPack: @unpack
 using SpecialFunctions: besselk, loggamma
-using StaticArrays: StaticArrays, StaticVector, MVector, SVector
+using StaticArrays: StaticArrays, MVector, SVector
 using Reexport: @reexport
 using TimerOutputs: TimerOutputs, print_timer, reset_timer!
 @reexport using TrixiBase: trixi_include

--- a/src/kernels/kernels.jl
+++ b/src/kernels/kernels.jl
@@ -25,15 +25,17 @@ function (kernel::AbstractKernel)(x)
 end
 
 # This allows to evaluate 1D kernels at a scalar, which is sometimes more convenient
-function (kernel::AbstractKernel{1})(x::Real, y::AbstractVector)
+# For multidimensional kernels, this is needed, such that evaluating the kernel at one scalar
+# evaluates the basic function, which is exploited, e.g., for plotting the kernel.
+function (kernel::AbstractKernel)(x::Real, y::AbstractVector)
     @assert length(y) == 1
     return kernel(SVector(x), y)
 end
-function (kernel::AbstractKernel{1})(x::AbstractVector, y::Real)
+function (kernel::AbstractKernel)(x::AbstractVector, y::Real)
     @assert length(x) == 1
     return kernel(x, SVector(y))
 end
-function (kernel::AbstractKernel{1})(x::Real, y::Real)
+function (kernel::AbstractKernel)(x::Real, y::Real)
     return kernel(SVector(x), SVector(y))
 end
 

--- a/src/kernels/kernels.jl
+++ b/src/kernels/kernels.jl
@@ -24,5 +24,18 @@ function (kernel::AbstractKernel)(x)
     return kernel(x, zero(x))
 end
 
+# This allows to evaluate 1D kernels at a scalar, which is sometimes more convenient
+function (kernel::AbstractKernel{1})(x::Real, y::AbstractVector)
+    @assert length(y) == 1
+    return kernel(SVector(x), y)
+end
+function (kernel::AbstractKernel{1})(x::AbstractVector, y::Real)
+    @assert length(x) == 1
+    return kernel(x, SVector(y))
+end
+function (kernel::AbstractKernel{1})(x::Real, y::Real)
+    return kernel(SVector(x), SVector(y))
+end
+
 include("radialsymmetric_kernel.jl")
 include("special_kernel.jl")

--- a/src/kernels/radialsymmetric_kernel.jl
+++ b/src/kernels/radialsymmetric_kernel.jl
@@ -42,7 +42,7 @@ function Phi(kernel::RadialSymmetricKernel{Dim}, x) where {Dim}
     return phi(kernel, r)
 end
 
-function (kernel::RadialSymmetricKernel)(x, y)
+function (kernel::RadialSymmetricKernel)(x::AbstractVector, y::AbstractVector)
     @assert length(x)==length(y) "x and y must have the same length"
     return Phi(kernel, x - y)
 end

--- a/src/kernels/special_kernel.jl
+++ b/src/kernels/special_kernel.jl
@@ -21,7 +21,7 @@ function TransformationKernel{Dim}(kernel, transformation) where {Dim}
                                                                              transformation)
 end
 
-function (kernel::TransformationKernel)(x, y)
+function (kernel::TransformationKernel)(x::AbstractVector, y::AbstractVector)
     @assert length(x) == length(y)
     K = kernel.kernel
     T = kernel.trafo
@@ -55,7 +55,7 @@ struct ProductKernel{Dim} <: AbstractKernel{Dim}
     end
 end
 
-function (kernel::ProductKernel)(x, y)
+function (kernel::ProductKernel)(x::AbstractVector, y::AbstractVector)
     @assert length(x) == length(y)
     res = eltype(x)(1.0)
     for k in kernel.kernels
@@ -102,7 +102,7 @@ struct SumKernel{Dim} <: AbstractKernel{Dim}
     end
 end
 
-function (kernel::SumKernel)(x, y)
+function (kernel::SumKernel)(x::AbstractVector, y::AbstractVector)
     @assert length(x) == length(y)
     res = 0.0
     for k in kernel.kernels

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,6 +11,6 @@ end
     using LinearAlgebra: norm, Symmetric, I
     using OrdinaryDiffEqRosenbrock: solve, Rodas5P
     import OrdinaryDiffEqNonlinearSolve
-    using StaticArrays: MVector
+    using StaticArrays: SVector, MVector
     using Meshes: Meshes, Sphere, Point, PointSet, RegularSampling
 end

--- a/test/test_unit.jl
+++ b/test/test_unit.jl
@@ -190,6 +190,10 @@ end
     @test order(kernel12) == 0
     @test isapprox(kernel12(x, y), kernel1(x, y) + kernel2(x, y))
     @test isapprox((kernel1 + kernel2)(x, y), kernel1(x, y) + kernel2(x, y))
+
+    # Test evaluating 1D kernels at a scalar
+    kernel13 = @test_nowarn GaussKernel{1}(shape_parameter = 2.0)
+    @test kernel13(3.1, 3.0) == kernel13(3.1, SVector(3.0)) == kernel13([3.1], 3.0)
 end
 
 @testitem "NodeSet" setup=[Setup, AdditionalImports] begin

--- a/test/test_unit.jl
+++ b/test/test_unit.jl
@@ -3,7 +3,7 @@
     @trixi_test_nowarn trixi_include(default_example(), n = 10)
 end
 
-@testitem "Kernels" setup=[Setup] begin
+@testitem "Kernels" setup=[Setup, AdditionalImports] begin
     x = [3.1, 3.0]
     y = [pi, 2.7]
 


### PR DESCRIPTION
Removing the broadcasting in the evaluation of a kernel in #126, lead to the side effect that evaluating 1D kernels at a scalar and a vector lead to an error, which I relied on before. This PR fixes this again by explicitly dispatching on these cases.