### PR TITLE
Allow passing a factorization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ for human readability.
 
 #### Added
 
+- Added a keyword argument `factorization_method` to `interpolate`, `interpolation_matrix`,
+  and `least_squares_matrix` to allow for different factorization methods ([#130]).
 - General floating point support ([#121]).
 
 #### Changed

--- a/examples/interpolation/interpolation_2d_sphere.jl
+++ b/examples/interpolation/interpolation_2d_sphere.jl
@@ -1,5 +1,6 @@
 using KernelInterpolation
 using Plots
+using LinearAlgebra: cholesky
 
 # function to interpolate
 f(x) = x[1] * x[2]

--- a/examples/interpolation/interpolation_2d_sphere.jl
+++ b/examples/interpolation/interpolation_2d_sphere.jl
@@ -14,7 +14,7 @@ values = f.(nodeset)
 
 kernel = InverseMultiquadricKernel{dim(nodeset)}()
 basis = StandardBasis(nodeset, kernel)
-itp = interpolate(basis, values)
+itp = interpolate(basis, values; factorization_method = cholesky)
 
 N = 500
 many_nodes = random_hypersphere(N, r, center)

--- a/src/interpolation.jl
+++ b/src/interpolation.jl
@@ -175,11 +175,15 @@ function interpolate(basis::AbstractBasis, values::Vector{RealT},
     q = length(ps)
 
     if nodeset == centers(basis)
-        factorization_method = isnothing(factorization_method) ? Symmetric : factorization_method
-        system_matrix = interpolation_matrix(basis, ps, regularization; factorization_method)
+        factorization_method = isnothing(factorization_method) ? Symmetric :
+                               factorization_method
+        system_matrix = interpolation_matrix(basis, ps, regularization;
+                                             factorization_method)
     else
-        factorization_method = isnothing(factorization_method) ? Matrix : factorization_method
-        system_matrix = least_squares_matrix(basis, nodeset, ps, regularization; factorization_method)
+        factorization_method = isnothing(factorization_method) ? Matrix :
+                               factorization_method
+        system_matrix = least_squares_matrix(basis, nodeset, ps, regularization;
+                                             factorization_method)
     end
     b = [values; zeros(RealT, q)]
     c = system_matrix \ b

--- a/src/interpolation.jl
+++ b/src/interpolation.jl
@@ -159,7 +159,7 @@ Otherwise, `nodeset` is set to `centers(basis)` or `centers`.
 
 A regularization can be applied to the kernel matrix using the `regularization` argument, cf. [`regularize!`](@ref).
 In addition, the `factorization_method` can be specified to determine how the system matrix is factorized. By default,
-the system matrix is just wrapped as a [`Symmetric`](@ref) matrix for interpolation and no factorization is applied
+the system matrix is just wrapped as a Symmetric matrix for interpolation and no factorization is applied
 for a least squares solution, but you can, e.g., also explicitly use `cholesky`, `lu`, or `qr` factorization.
 """
 function interpolate(basis::AbstractBasis, values::Vector{RealT},

--- a/src/kernel_matrices.jl
+++ b/src/kernel_matrices.jl
@@ -58,8 +58,8 @@ function polynomial_matrix(nodeset::NodeSet, ps)
 end
 
 @doc raw"""
-    interpolation_matrix(centers, kernel, ps, regularization = NoRegularization())
-    interpolation_matrix(basis, ps, regularization)
+    interpolation_matrix(centers, kernel, ps, regularization = NoRegularization(); factorization_method = Symmetric)
+    interpolation_matrix(basis, ps, regularization; factorization_method = Symmetric)
 
 Return the interpolation matrix for the `basis`, polynomials `ps`, and `regularization`.
 For the [`StandardBasis`](@ref), the interpolation matrix is defined as
@@ -68,9 +68,12 @@ For the [`StandardBasis`](@ref), the interpolation matrix is defined as
 ```
 where ``K`` is the [`regularize!`](@ref)d [`kernel_matrix`](@ref) and ``P`` the [`polynomial_matrix`](@ref).
 If a node set of `centers` and a `kernel` are given, the interpolation matrix is computed for the [`StandardBasis`](@ref).
+Additionally, you can specify a `factorization_method` to use for the system matrix. By default, the system matrix is
+just wrapped as a [`Symmetric`](@ref) matrix, but you can, e.g., also explicitly use `cholesky`, `lu`, or `qr` factorization.
 """
 function interpolation_matrix(basis::AbstractBasis, ps,
-                              regularization::AbstractRegularization = NoRegularization())
+                              regularization::AbstractRegularization = NoRegularization();
+                              factorization_method = Symmetric)
     q = length(ps)
     k_matrix = kernel_matrix(basis)
     regularize!(k_matrix, regularization)
@@ -81,30 +84,30 @@ function interpolation_matrix(basis::AbstractBasis, ps,
         system_matrix = [k_matrix p_matrix
                          p_matrix' zeros(eltype(k_matrix), q, q)]
     else
-        # We could also use `cholesky` here because usually `k_matrix` is
-        # symmetric positive definite, but this might not be the case if
-        # the user explicitly sets `m = 0` even though the kernel is not
-        # strictly positive definite or the matrix might be numerically not spd.
-        # TODO: Think of an interface to allow for general matrix factorizations.
         system_matrix = k_matrix
     end
-    return Symmetric(system_matrix)
+    return factorization_method(system_matrix)
 end
 
 # This should be the same as `kernel_matrix(basis)`
 function interpolation_matrix(::LagrangeBasis, ps,
-                              ::AbstractRegularization = NoRegularization())
+                              ::AbstractRegularization = NoRegularization();
+                              factorization_method = Symmetric)
     return I
 end
 
 function interpolation_matrix(centers::NodeSet, kernel::AbstractKernel, ps,
-                              regularization::AbstractRegularization = NoRegularization())
-    interpolation_matrix(StandardBasis(centers, kernel), ps, regularization)
+                              regularization::AbstractRegularization = NoRegularization();
+                              factorization_method = Symmetric)
+    interpolation_matrix(StandardBasis(centers, kernel), ps, regularization;
+                         factorization_method)
 end
 
 @doc raw"""
-    least_squares_matrix(basis, nodeset, ps, regularization = NoRegularization())
-    least_squares_matrix(centers, nodeset, kernel, ps, regularization = NoRegularization())
+    least_squares_matrix(basis, nodeset, ps, regularization = NoRegularization();
+                         factorization_method = Matrix)
+    least_squares_matrix(centers, nodeset, kernel, ps, regularization = NoRegularization();
+                         factorization_method = Matrix)
 
 Return the least squares matrix for the `basis`, `nodeset`, polynomials `ps`, and `regularization`.
 For the [`StandardBasis`](@ref), the least squares matrix is defined as
@@ -114,30 +117,42 @@ For the [`StandardBasis`](@ref), the least squares matrix is defined as
 where ``K`` is the [`regularize!`](@ref)d [`kernel_matrix`](@ref), ``P_1`` the [`polynomial_matrix`](@ref)
 for the `nodeset` and ``P_2`` the [`polynomial_matrix`](@ref)` for the `centers`.
 If a `nodeset` and `kernel` are given, the least squares matrix is computed for the [`StandardBasis`](@ref).
+Additionally, you can specify a `factorization_method` to use for the system matrix. By default, the system matrix is
+not factorized, but you can, e.g., also explicitly use the `qr` factorization.
 """
 function least_squares_matrix(basis::AbstractBasis, nodeset::NodeSet, ps,
-                              regularization::AbstractRegularization = NoRegularization())
+                              regularization::AbstractRegularization = NoRegularization();
+                              factorization_method = Matrix)
     q = length(ps)
     k_matrix = kernel_matrix(basis, nodeset)
     regularize!(k_matrix, regularization)
-    p_matrix1 = polynomial_matrix(nodeset, ps)
-    p_matrix2 = polynomial_matrix(centers(basis), ps)
-    system_matrix = [k_matrix p_matrix1
-                     p_matrix2' zeros(eltype(k_matrix), q, q)]
-    return system_matrix
+    # We could always use the first branch, but this is more efficient
+    # for the case where we don't use polynomial augmentation (q == 0).
+    if q > 0
+        p_matrix1 = polynomial_matrix(nodeset, ps)
+        p_matrix2 = polynomial_matrix(centers(basis), ps)
+        system_matrix = [k_matrix p_matrix1
+                         p_matrix2' zeros(eltype(k_matrix), q, q)]
+    else
+        system_matrix = k_matrix
+    end
+    return factorization_method(system_matrix)
 end
 
 function least_squares_matrix(basis::LagrangeBasis, nodeset::NodeSet, ps,
-                              regularization::AbstractRegularization = NoRegularization())
+                              regularization::AbstractRegularization = NoRegularization();
+                              factorization_method = Matrix)
     k_matrix = kernel_matrix(basis, nodeset)
     regularize!(k_matrix, regularization)
-    return k_matrix
+    return factorization_method(k_matrix)
 end
 
 function least_squares_matrix(centers::NodeSet, nodeset::NodeSet, kernel::AbstractKernel,
                               ps,
-                              regularization::AbstractRegularization = NoRegularization())
-    least_squares_matrix(StandardBasis(centers, kernel), nodeset, ps, regularization)
+                              regularization::AbstractRegularization = NoRegularization();
+                              factorization_method = Matrix)
+    least_squares_matrix(StandardBasis(centers, kernel), nodeset, ps, regularization;
+                         factorization_method)
 end
 
 @doc raw"""

--- a/src/kernel_matrices.jl
+++ b/src/kernel_matrices.jl
@@ -69,7 +69,7 @@ For the [`StandardBasis`](@ref), the interpolation matrix is defined as
 where ``K`` is the [`regularize!`](@ref)d [`kernel_matrix`](@ref) and ``P`` the [`polynomial_matrix`](@ref).
 If a node set of `centers` and a `kernel` are given, the interpolation matrix is computed for the [`StandardBasis`](@ref).
 Additionally, you can specify a `factorization_method` to use for the system matrix. By default, the system matrix is
-just wrapped as a [`Symmetric`](@ref) matrix, but you can, e.g., also explicitly use `cholesky`, `lu`, or `qr` factorization.
+just wrapped as a `Symmetric` matrix, but you can, e.g., also explicitly use `cholesky`, `lu`, or `qr` factorization.
 """
 function interpolation_matrix(basis::AbstractBasis, ps,
                               regularization::AbstractRegularization = NoRegularization();

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,7 +8,7 @@ using TestItemRunner
 end
 
 @testsnippet AdditionalImports begin
-    using LinearAlgebra: norm, Symmetric, I
+    using LinearAlgebra: LinearAlgebra, norm, cholesky, qr, Symmetric, Cholesky, I
     using OrdinaryDiffEqRosenbrock: solve, Rodas5P
     import OrdinaryDiffEqNonlinearSolve
     using StaticArrays: SVector, MVector

--- a/test/test_unit.jl
+++ b/test/test_unit.jl
@@ -789,7 +789,7 @@ end
     @test isapprox(itp([0.5, 0.5]), 1.0)
     @test isapprox(kernel_norm(itp), 0.0, atol = 1e-15)
 
-    itp = @test_nowarn interpolate(nodes, ff,
+    itp = @test_nowarn interpolate(centers, nodes, ff,
                                    Matern52Kernel{dim(nodes)}(shape_parameter = 0.5);
                                    factorization_method = qr)
     @test system_matrix(itp) isa LinearAlgebra.QRCompactWY

--- a/test/test_unit.jl
+++ b/test/test_unit.jl
@@ -789,7 +789,9 @@ end
     @test isapprox(itp([0.5, 0.5]), 1.0)
     @test isapprox(kernel_norm(itp), 0.0, atol = 1e-15)
 
-    itp = @test_nowarn interpolate(nodes, ff, kernel; factorization_method = qr)
+    itp = @test_nowarn interpolate(nodes, ff,
+                                   Matern52Kernel{dim(nodes)}(shape_parameter = 0.5);
+                                   factorization_method = qr)
     @test system_matrix(itp) isa LinearAlgebra.QRCompactWY
 
     # Least squares with LagrangeBasis (not really recommended because you still need to solve a linear system)

--- a/test/test_unit.jl
+++ b/test/test_unit.jl
@@ -713,6 +713,9 @@ end
     @test isapprox(itp([0.5, 0.5]), 1.115625820404527)
     @test isapprox(kernel_norm(itp), 2.5193566316951626)
 
+    itp = @test_nowarn interpolate(nodes, ff, kernel; factorization_method = cholesky)
+    @test system_matrix(itp) isa Cholesky
+
     # Conditionally positive definite kernel
     # Interpolation
     kernel = ThinPlateSplineKernel{dim(nodes)}()
@@ -785,6 +788,9 @@ end
     @test size(system_matrix(itp)) == (7, 6)
     @test isapprox(itp([0.5, 0.5]), 1.0)
     @test isapprox(kernel_norm(itp), 0.0, atol = 1e-15)
+
+    itp = @test_nowarn interpolate(nodes, ff, kernel; factorization_method = qr)
+    @test system_matrix(itp) isa LinearAlgebra.QRCompactWY
 
     # Least squares with LagrangeBasis (not really recommended because you still need to solve a linear system)
     basis = LagrangeBasis(centers, kernel)


### PR DESCRIPTION
This adds some flexibility to use different factorization methods for solving the linear system. I learned that `factorize(Symetric(A))` (called within `\`) doesn't automatically use a `cholesky` decomposition if the matrix `isposdef`. see also https://github.com/JuliaLang/julia/pull/54775. Thus, previously it was not possible to use a `cholesky` decomposition, which should be used in many cases at the kernel matrix is often known to be symmetric and positive definite. Now, it is possible to pass `cholesky` to `factorization_method` to perform a Cholesky factorization (and similarly for `lu`, `qr`, and possible other factorizations).