### PR TITLE
Define slicing of NodeSets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ KernelInterpolation.jl follows the interpretation of
 used in the Julia ecosystem. Notable changes will be documented in this file
 for human readability.
 
+## Changes in the v0.3 lifecycle
+
+#### Added
+
+- Allow passing a factorization to `interpolate` ([#130]).
+
+#### Changed
+
+- Define slicing for `NodeSet`s and deprecate `values_along_dim` ([#139]).
+- Fix order of `PolyharmonicSplineKernel` to return an integer ([#127]).
+
 ## Changes when updating to v0.3 from v0.2.x
 
 #### Added

--- a/docs/src/interpolation.md
+++ b/docs/src/interpolation.md
@@ -203,8 +203,8 @@ To visualize the interpolation, we can use evaluate the interpolant on a grid of
 ```@example interpolation
 N = 50
 nodes_grid = homogeneous_hypercube(N, (0.0, 0.0), (1.0, 1.0))
-x = unique(values_along_dim(nodes_grid, 1))
-y = unique(values_along_dim(nodes_grid, 2))
+x = unique(nodes_grid[:, 1])
+y = unique(nodes_grid[:, 2])
 z_itp = reshape(itp.(nodes_grid), (N, N))'
 p1 = plot(x, y, z_itp, st = :heatmap, colorbar = :none, title = "Interpolation")
 z_true = reshape(f.(nodes_grid), (N, N))'

--- a/src/KernelInterpolation.jl
+++ b/src/KernelInterpolation.jl
@@ -60,7 +60,7 @@ export PoissonEquation, EllipticEquation, AdvectionEquation, HeatEquation,
        AdvectionDiffusionEquation
 export SpatialDiscretization, Semidiscretization, semidiscretize
 export NoRegularization, L2Regularization
-export NodeSet, empty_nodeset, separation_distance, dim, eachdim, values_along_dim,
+export NodeSet, empty_nodeset, separation_distance, dim, eachdim,
        distance_matrix, random_hypercube, random_hypercube_boundary, homogeneous_hypercube,
        homogeneous_hypercube_boundary, random_hypersphere, random_hypersphere_boundary
 export interpolation_kernel, nodeset, coefficients, kernel_coefficients,

--- a/src/io.jl
+++ b/src/io.jl
@@ -13,7 +13,7 @@ function vtk_save(filename, nodeset::NodeSet, functions_or_vectors...;
                   keys = "value_" .* string.(eachindex(functions_or_vectors)))
     @assert dim(nodeset)<=3 "Only 1D, 2D, and 3D data can be saved to VTK files."
     cells = [MeshCell(VTKCellTypes.VTK_VERTEX, (i,)) for i in eachindex(nodeset)]
-    points = values_along_dim.(Ref(nodeset), eachdim(nodeset))
+    points = Base.getindex.(Ref(nodeset), :, eachdim(nodeset))
     vtk_grid(filename, points..., cells, append = false) do vtk
         for (i, fun_or_vec) in enumerate(functions_or_vectors)
             if fun_or_vec isa AbstractArray
@@ -37,7 +37,7 @@ function add_to_pvd(filename, pvd, time, nodeset::NodeSet, functions_or_vectors.
                     keys = "value_" .* string.(eachindex(functions_or_vectors)))
     @assert dim(nodeset)<=3 "Only 1D, 2D, and 3D data can be saved to VTK files."
     cells = [MeshCell(VTKCellTypes.VTK_VERTEX, (i,)) for i in eachindex(nodeset)]
-    points = values_along_dim.(Ref(nodeset), eachdim(nodeset))
+    points = Base.getindex.(Ref(nodeset), :, eachdim(nodeset))
     vtk_grid(filename, points..., cells, append = false) do vtk
         for (i, fun_or_vec) in enumerate(functions_or_vectors)
             if fun_or_vec isa AbstractArray

--- a/src/nodes.jl
+++ b/src/nodes.jl
@@ -125,6 +125,15 @@ function Base.similar(nodeset::NodeSet{Dim, RealT}, ::Type{T}, n::Int) where {Di
 end
 Base.getindex(nodeset::NodeSet, i::Int) = nodeset.nodes[i]
 Base.getindex(nodeset::NodeSet, is::AbstractVector) = nodeset.nodes[is]
+function Base.getindex(nodeset::NodeSet, ::Colon, i::Int)
+    @assert dim(nodeset) >= i
+    x_i = Vector{eltype(nodeset)}(undef, length(nodeset))
+    for (j, node) in enumerate(nodeset)
+        x_i[j] = node[i]
+    end
+    return x_i
+end
+
 Base.firstindex(nodeset::NodeSet) = firstindex(nodeset.nodes)
 Base.lastindex(nodeset::NodeSet) = lastindex(nodeset.nodes)
 Base.keys(nodeset::NodeSet) = keys(nodeset.nodes)
@@ -206,20 +215,7 @@ function distance_matrix(nodeset1::NodeSet, nodeset2::NodeSet)
     return D
 end
 
-"""
-    values_along_dim(nodeset::NodeSet, i::Int)
-
-Convenience function to return all ``x_i``-values of the nodes, i.e. the `i`-th component of each node.
-Supported for `nodeset` with `dim(nodeset) >= i`.
-"""
-function values_along_dim(nodeset::NodeSet, i::Int)
-    @assert dim(nodeset) >= i
-    x_i = Vector{eltype(nodeset)}(undef, length(nodeset))
-    for (j, node) in enumerate(nodeset)
-        x_i[j] = node[i]
-    end
-    return x_i
-end
+@deprecate values_along_dim(nodeset::NodeSet, i::Int) nodeset[:, i]
 
 # Some convenience function to create some specific `NodeSet`s
 """

--- a/src/visualization.jl
+++ b/src/visualization.jl
@@ -6,8 +6,8 @@
         x, kernel.(x)
     elseif Dim == 2
         nodeset = homogeneous_hypercube(N, x_min, x_max; dim = 2)
-        x = unique(values_along_dim(nodeset, 1))
-        y = unique(values_along_dim(nodeset, 2))
+        x = unique(nodeset[:, 1])
+        y = unique(nodeset[:, 2])
         z = reshape(kernel.(nodeset), (N, N))
         seriestype --> :heatmap # :contourf
         title --> get_name(kernel)
@@ -25,12 +25,12 @@ end
 
 @recipe function f(nodeset::NodeSet, kernel::AbstractKernel)
     if dim(nodeset) == 1
-        x = values_along_dim(nodeset, 1)
+        x = nodeset[:, 1]
         title --> get_name(kernel)
         x, kernel.(Ref(0.0), x)
     elseif dim(nodeset) == 2
-        x = values_along_dim(nodeset, 1)
-        y = values_along_dim(nodeset, 2)
+        x = nodeset[:, 1]
+        y = nodeset[:, 2]
         seriestype --> :scatter
         label --> "nodes"
         title --> get_name(kernel)
@@ -42,7 +42,7 @@ end
 
 @recipe function f(nodeset::NodeSet)
     if dim(nodeset) == 1
-        x = values_along_dim(nodeset, 1)
+        x = nodeset[:, 1]
         seriestype := :scatter
         label --> "nodes"
         xguide --> "x"
@@ -50,8 +50,8 @@ end
         yticks --> []
         x, zero(x)
     elseif dim(nodeset) == 2
-        x = values_along_dim(nodeset, 1)
-        y = values_along_dim(nodeset, 2)
+        x = nodeset[:, 1]
+        y = nodeset[:, 2]
         seriestype --> :scatter
         label --> "nodes"
         xguide --> "x"
@@ -70,9 +70,9 @@ end
             x, y
         end
     elseif dim(nodeset) == 3
-        x = values_along_dim(nodeset, 1)
-        y = values_along_dim(nodeset, 2)
-        z = values_along_dim(nodeset, 3)
+        x = nodeset[:, 1]
+        y = nodeset[:, 2]
+        z = nodeset[:, 3]
         seriestype --> :scatter
         label --> "nodes"
         xguide --> "x"
@@ -88,7 +88,7 @@ end
     if dim(nodeset) == 1
         if training_nodes
             @series begin
-                x = values_along_dim(itp.nodeset, 1)
+                x = centers(itp)[:, 1]
                 seriestype := :scatter
                 markershape --> :star
                 label --> "training nodes"
@@ -96,7 +96,7 @@ end
             end
         end
         @series begin
-            x = values_along_dim(nodeset, 1)
+            x = nodeset[:, 1]
             perm = sortperm(x)
             label --> "interpolation"
             xguide --> "x"
@@ -106,8 +106,8 @@ end
     elseif dim(nodeset) == 2
         if training_nodes
             @series begin
-                x = values_along_dim(centers(itp), 1)
-                y = values_along_dim(centers(itp), 2)
+                x = centers(itp)[:, 1]
+                y = centers(itp)[:, 2]
                 seriestype := :scatter
                 markershape --> :star
                 markersize --> 10
@@ -116,8 +116,8 @@ end
             end
         end
         @series begin
-            x = values_along_dim(nodeset, 1)
-            y = values_along_dim(nodeset, 2)
+            x = nodeset[:, 1]
+            y = nodeset[:, 2]
             seriestype --> :scatter
             label --> "interpolation"
             xguide --> "x"
@@ -136,8 +136,8 @@ end
         x, itp.(x)
     elseif dim(itp) == 2
         nodeset = homogeneous_hypercube(N, x_min, x_max; dim = 2)
-        x = unique(values_along_dim(nodeset, 1))
-        y = unique(values_along_dim(nodeset, 2))
+        x = unique(nodeset[:, 1])
+        y = unique(nodeset[:, 2])
         z = reshape(itp.(nodeset), (N, N))'
         xguide --> "x"
         yguide --> "y"
@@ -151,7 +151,7 @@ end
 @recipe function f(nodeset::NodeSet, vals::AbstractVector)
     if dim(nodeset) == 1
         @series begin
-            x = values_along_dim(nodeset, 1)
+            x = nodeset[:, 1]
             perm = sortperm(x)
             label --> "f"
             xguide --> "x"
@@ -160,8 +160,8 @@ end
         end
     elseif dim(nodeset) == 2
         @series begin
-            x = values_along_dim(nodeset, 1)
-            y = values_along_dim(nodeset, 2)
+            x = nodeset[:, 1]
+            y = nodeset[:, 2]
             seriestype --> :scatter
             label --> "f"
             xguide --> "x"

--- a/test/test_unit.jl
+++ b/test/test_unit.jl
@@ -219,9 +219,9 @@ end
     f(x) = x[1] + x[2]
     ff = @test_nowarn f.(nodeset1)
     @test ff == [0.0, 1.0, 1.0, 2.0]
-    dim1 = @test_nowarn values_along_dim(nodeset1, 1)
+    dim1 = @test_nowarn nodeset1[:, 1]
     @test dim1 == [0.0, 1.0, 0.0, 1.0]
-    dim2 = @test_nowarn values_along_dim(nodeset1, 2)
+    dim2 = @test_nowarn nodeset1[:, 2]
     @test dim2 == [0.0, 0.0, 1.0, 1.0]
     @test distance_matrix(nodeset1, nodeset1) == [0.0 1.0 1.0 1.4142135623730951
            1.0 0.0 1.4142135623730951 1.0


### PR DESCRIPTION
`values_along_dim` was a strange name for something that is just slicing. So I deprecated `values_along_dim` in favor of proper slicing.