### PR TITLE
Make solving PDEs independent of basis type

### DIFF
--- a/examples/PDEs/heat_2d_lagrange_basis.jl
+++ b/examples/PDEs/heat_2d_lagrange_basis.jl
@@ -1,0 +1,37 @@
+using KernelInterpolation
+using OrdinaryDiffEqRosenbrock, OrdinaryDiffEqNonlinearSolve
+using Plots
+
+# right-hand-side of heat equation
+function f(t, x, equations)
+    return exp(t) * (x[1] * (x[1] - 1) * x[2] * (x[2] - 1) -
+            2 * equations.diffusivity * (x[1] * (x[1] - 1) + x[2] * (x[2] - 1)))
+end
+pde = HeatEquation(2.0, f)
+
+# analytical solution
+u(t, x, equations) = exp(t) * x[1] * (x[1] - 1) * x[2] * (x[2] - 1)
+
+n = 10
+nodeset_inner = homogeneous_hypercube(n, (0.1, 0.1), (0.9, 0.9); dim = 2)
+n_boundary = 3
+nodeset_boundary = homogeneous_hypercube_boundary(n_boundary; dim = 2)
+# Dirichlet boundary condition
+g(t, x) = 0.0
+
+centers = merge(nodeset_inner, nodeset_boundary)
+kernel = WendlandKernel{2}(3, shape_parameter = 0.3)
+basis = LagrangeBasis(centers, kernel)
+spatial_discretization = SpatialDiscretization(pde, nodeset_inner, g, nodeset_boundary,
+                                               basis)
+semi = Semidiscretization(spatial_discretization, u)
+
+tspan = (0.0, 1.0)
+ode = semidiscretize(semi, tspan)
+sol = solve(ode, Rodas5P(), saveat = 0.01)
+titp = TemporalInterpolation(sol)
+
+many_nodes = homogeneous_hypercube(20; dim = 2)
+
+plot(many_nodes, titp(last(tspan)))
+plot!(many_nodes, x -> u(last(tspan), x, pde), label = "analytical solution")

--- a/examples/PDEs/heat_2d_lagrange_basis.jl
+++ b/examples/PDEs/heat_2d_lagrange_basis.jl
@@ -20,7 +20,7 @@ nodeset_boundary = homogeneous_hypercube_boundary(n_boundary; dim = 2)
 g(t, x) = 0.0
 
 centers = merge(nodeset_inner, nodeset_boundary)
-kernel = MultiquadricKernel{2}(shape_parameter = 1.5)
+kernel = WendlandKernel{2}(3, shape_parameter = 0.3)
 basis = LagrangeBasis(centers, kernel)
 spatial_discretization = SpatialDiscretization(pde, nodeset_inner, g, nodeset_boundary,
                                                basis)

--- a/examples/PDEs/heat_2d_lagrange_basis.jl
+++ b/examples/PDEs/heat_2d_lagrange_basis.jl
@@ -20,7 +20,7 @@ nodeset_boundary = homogeneous_hypercube_boundary(n_boundary; dim = 2)
 g(t, x) = 0.0
 
 centers = merge(nodeset_inner, nodeset_boundary)
-kernel = WendlandKernel{2}(3, shape_parameter = 0.3)
+kernel = MultiquadricKernel{2}(shape_parameter = 1.5)
 basis = LagrangeBasis(centers, kernel)
 spatial_discretization = SpatialDiscretization(pde, nodeset_inner, g, nodeset_boundary,
                                                basis)

--- a/examples/PDEs/poisson_2d_lagrange_basis.jl
+++ b/examples/PDEs/poisson_2d_lagrange_basis.jl
@@ -1,0 +1,27 @@
+using KernelInterpolation
+using Plots
+
+# right-hand-side of Poisson equation
+f(x, equations) = 5 / 4 * pi^2 * sinpi(x[1]) * cospi(x[2] / 2)
+pde = PoissonEquation(f)
+
+# analytical solution of equation
+u(x, equations) = sinpi(x[1]) * cospi(x[2] / 2)
+
+n = 10
+nodeset_inner = homogeneous_hypercube(n, (0.1, 0.1), (0.9, 0.9); dim = 2)
+n_boundary = 3
+nodeset_boundary = homogeneous_hypercube_boundary(n_boundary; dim = 2)
+# Dirichlet boundary condition (here taken from analytical solution)
+g(x) = u(x, pde)
+
+centers = merge(nodeset_inner, nodeset_boundary)
+kernel = WendlandKernel{2}(3, shape_parameter = 0.3)
+basis = LagrangeBasis(centers, kernel)
+sd = SpatialDiscretization(pde, nodeset_inner, g, nodeset_boundary, basis)
+itp = solve_stationary(sd)
+
+many_nodes = homogeneous_hypercube(20; dim = 2)
+
+plot(many_nodes, itp)
+plot!(many_nodes, x -> u(x, pde), label = "analytical solution")

--- a/examples/PDEs/poisson_2d_lagrange_basis.jl
+++ b/examples/PDEs/poisson_2d_lagrange_basis.jl
@@ -16,7 +16,7 @@ nodeset_boundary = homogeneous_hypercube_boundary(n_boundary; dim = 2)
 g(x) = u(x, pde)
 
 centers = merge(nodeset_inner, nodeset_boundary)
-kernel = MultiquadricKernel{2}(shape_parameter = 2.0)
+kernel = WendlandKernel{2}(3, shape_parameter = 0.3)
 basis = LagrangeBasis(centers, kernel)
 sd = SpatialDiscretization(pde, nodeset_inner, g, nodeset_boundary, basis)
 itp = solve_stationary(sd)

--- a/examples/PDEs/poisson_2d_lagrange_basis.jl
+++ b/examples/PDEs/poisson_2d_lagrange_basis.jl
@@ -16,7 +16,7 @@ nodeset_boundary = homogeneous_hypercube_boundary(n_boundary; dim = 2)
 g(x) = u(x, pde)
 
 centers = merge(nodeset_inner, nodeset_boundary)
-kernel = WendlandKernel{2}(3, shape_parameter = 0.3)
+kernel = MultiquadricKernel{2}(shape_parameter = 2.0)
 basis = LagrangeBasis(centers, kernel)
 sd = SpatialDiscretization(pde, nodeset_inner, g, nodeset_boundary, basis)
 itp = solve_stationary(sd)

--- a/src/basis.jl
+++ b/src/basis.jl
@@ -118,7 +118,7 @@ struct LagrangeBasis{Dim, RealT, Kernel, I <: AbstractInterpolation, Monomials, 
     end
 end
 
-Base.getindex(basis::LagrangeBasis, i) = x -> basis.basis_functions[i](x)
+Base.getindex(basis::LagrangeBasis, i) = basis.basis_functions[i]
 Base.collect(basis::LagrangeBasis) = basis.basis_functions
 # Polynomials are already inherently defined included in the basis
 order(::LagrangeBasis) = 0

--- a/src/discretization.jl
+++ b/src/discretization.jl
@@ -94,9 +94,12 @@ end
 
 Semidiscretization of a partial differential equation with Dirichlet boundary conditions and initial condition `initial_condition`. The `boundary_condition` function
 can be time- and space-dependent. The `initial_condition` function is time- and space-dependent to be able to reuse it as analytical solution if available. If no
-analytical solution is available, the time variable can be ignored in the `initial_condition` function. The `centers` are the centers of the kernel functions. By default,
-`centers` is set to `merge(nodeset_inner, nodeset_boundary)`. Note that `centers` needs to have the same number of nodes as the number of nodes in the domain and on the boundary
-because OrdinaryDiffEq.jl does not support DAEs with rectangular mass matrices.
+analytical solution is available, the time variable can be ignored in the `initial_condition` function.
+If a basis is passed via [`SpatialDiscretization`](@ref), this basis is used consistently in the semidiscretization.
+For convenience constructors with `centers` and `kernel`, a [`StandardBasis`](@ref) is used and by default
+`centers` is set to `merge(nodeset_inner, nodeset_boundary)`.
+The number of basis functions must be equal to the number of inner and boundary nodes because OrdinaryDiffEq.jl
+does not support DAEs with rectangular mass matrices.
 
 See also [`SpatialDiscretization`](@ref), [`semidiscretize`](@ref).
 """
@@ -109,18 +112,17 @@ end
 function Semidiscretization(spatial_discretization::SpatialDiscretization,
                             initial_condition)
     @unpack equations, nodeset_inner, boundary_condition, nodeset_boundary, basis = spatial_discretization
-    @unpack centers, kernel = basis
-    @assert length(centers)==length(nodeset_inner) + length(nodeset_boundary) "The number of centers must be equal to the number of inner and boundary nodes."
-    k_matrix_inner = kernel_matrix(centers, nodeset_inner, kernel)
-    k_matrix_boundary = kernel_matrix(centers, nodeset_boundary, kernel)
-    # whole kernel matrix is not needed for rhs, but for initial condition
-    k_matrix = [k_matrix_inner
-                k_matrix_boundary]
-    pdeb_matrix = pde_boundary_matrix(equations, nodeset_inner, nodeset_boundary, centers,
-                                      kernel)
-    m_matrix = [k_matrix_inner
-                zeros(eltype(k_matrix_inner), size(k_matrix_boundary)...)]
-    cache = (; kernel_matrix = k_matrix, mass_matrix = m_matrix,
+    nodeset = merge(nodeset_inner, nodeset_boundary)
+    @assert length(basis) == length(nodeset) "The basis must have the same number of functions as the number of inner and boundary nodes."
+    basis_matrix_inner = kernel_matrix(basis, nodeset_inner)
+    basis_matrix_boundary = kernel_matrix(basis, nodeset_boundary)
+    # whole basis matrix is not needed for rhs, but for initial condition
+    basis_matrix = [basis_matrix_inner
+                    basis_matrix_boundary]
+    pdeb_matrix = pde_boundary_matrix(equations, nodeset_inner, nodeset_boundary, basis)
+    m_matrix = [basis_matrix_inner
+                zeros(eltype(basis_matrix_inner), size(basis_matrix_boundary)...)]
+    cache = (; kernel_matrix = basis_matrix, mass_matrix = m_matrix,
              pde_boundary_matrix = pdeb_matrix)
     return Semidiscretization{typeof(initial_condition), typeof(cache)}(spatial_discretization,
                                                                         initial_condition,

--- a/src/discretization.jl
+++ b/src/discretization.jl
@@ -74,10 +74,8 @@ function solve_stationary(spatial_discretization::SpatialDiscretization{Dim, Rea
                                                                                             RealT
                                                                                             }
     @unpack equations, nodeset_inner, boundary_condition, nodeset_boundary, basis = spatial_discretization
-    @unpack centers, kernel = basis
 
-    system_matrix = pde_boundary_matrix(equations, nodeset_inner, nodeset_boundary, centers,
-                                        kernel)
+    system_matrix = pde_boundary_matrix(equations, nodeset_inner, nodeset_boundary, basis)
     b = [rhs(nodeset_inner, equations); boundary_condition.(nodeset_boundary)]
     c = system_matrix \ b
 
@@ -97,7 +95,7 @@ end
 Semidiscretization of a partial differential equation with Dirichlet boundary conditions and initial condition `initial_condition`. The `boundary_condition` function
 can be time- and space-dependent. The `initial_condition` function is time- and space-dependent to be able to reuse it as analytical solution if available. If no
 analytical solution is available, the time variable can be ignored in the `initial_condition` function. The `centers` are the centers of the kernel functions. By default,
-`centers` is set to `merge(nodeset_inner, nodeset_boundary)`. Note that `centers` needs to have the center number of nodes as the number of nodes in the domain and on the boundary
+`centers` is set to `merge(nodeset_inner, nodeset_boundary)`. Note that `centers` needs to have the same number of nodes as the number of nodes in the domain and on the boundary
 because OrdinaryDiffEq.jl does not support DAEs with rectangular mass matrices.
 
 See also [`SpatialDiscretization`](@ref), [`semidiscretize`](@ref).

--- a/src/discretization.jl
+++ b/src/discretization.jl
@@ -113,7 +113,7 @@ function Semidiscretization(spatial_discretization::SpatialDiscretization,
                             initial_condition)
     @unpack equations, nodeset_inner, boundary_condition, nodeset_boundary, basis = spatial_discretization
     nodeset = merge(nodeset_inner, nodeset_boundary)
-    @assert length(basis) == length(nodeset) "The basis must have the same number of functions as the number of inner and boundary nodes."
+    @assert length(basis)==length(nodeset) "The basis must have the same number of functions as the number of inner and boundary nodes."
     basis_matrix_inner = kernel_matrix(basis, nodeset_inner)
     basis_matrix_boundary = kernel_matrix(basis, nodeset_boundary)
     # whole basis matrix is not needed for rhs, but for initial condition

--- a/src/equations.jl
+++ b/src/equations.jl
@@ -1,5 +1,7 @@
 abstract type AbstractEquation end
 
+const DifferentialOperatorOrEquation = Union{AbstractDifferentialOperator, AbstractEquation}
+
 abstract type AbstractStationaryEquation <: AbstractEquation end
 
 function rhs(nodeset::NodeSet, equations::AbstractStationaryEquation)

--- a/src/interpolation.jl
+++ b/src/interpolation.jl
@@ -212,6 +212,7 @@ function (itp::Interpolation)(x)
         s += c[j] * bas[j](x)
     end
 
+    # This works also for the `LagrangeBasis` because it does not have additional polynomials, i.e., `d` is empty
     d = polynomial_coefficients(itp)
     ps = polynomial_basis(itp)
     xx = polyvars(itp)
@@ -235,6 +236,17 @@ function (diff_op_or_pde::Union{AbstractDifferentialOperator, AbstractStationary
     s = zero(eltype(x))
     for j in eachindex(c)
         s += c[j] * diff_op_or_pde(kernel, x, xis[j])
+    end
+    return s
+end
+
+function (diff_op_or_pde::Union{AbstractDifferentialOperator, AbstractStationaryEquation})(itp::Interpolation{<:LagrangeBasis},
+                                                                                           x)
+    c = kernel_coefficients(itp)
+    bas = basis(itp)
+    s = zero(eltype(x))
+    for j in eachindex(c)
+        s += c[j] * diff_op_or_pde(bas[j], x)
     end
     return s
 end

--- a/src/interpolation.jl
+++ b/src/interpolation.jl
@@ -228,70 +228,42 @@ function (itp::Interpolation)(x::RealT) where {RealT <: Real}
     return itp([x])
 end
 
-function (diff_op_or_pde::Union{AbstractDifferentialOperator, AbstractStationaryEquation})(itp::Interpolation,
-                                                                                           x)
+function (diff_op_or_pde::DifferentialOperatorOrEquation)(s, itp::Interpolation, x)
     kernel = interpolation_kernel(itp)
     xis = centers(itp)
     c = kernel_coefficients(itp)
-    s = zero(eltype(x))
     for j in eachindex(c)
         s += c[j] * diff_op_or_pde(kernel, x, xis[j])
     end
     return s
 end
 
-function (diff_op_or_pde::Union{AbstractDifferentialOperator, AbstractStationaryEquation})(itp::Interpolation{<:LagrangeBasis},
-                                                                                           x)
+function (diff_op_or_pde::DifferentialOperatorOrEquation)(s,
+                                                          itp::Interpolation{<:LagrangeBasis},
+                                                          x)
     c = kernel_coefficients(itp)
     bas = basis(itp)
-    s = zero(eltype(x))
     for j in eachindex(c)
         s += c[j] * diff_op_or_pde(bas[j], x)
     end
     return s
 end
 
-function (equations::AbstractTimeDependentEquation)(itp::Interpolation, x)
-    kernel = interpolation_kernel(itp)
-    xis = centers(itp)
-    c = kernel_coefficients(itp)
-    s = zero(eltype(x))
-    for j in eachindex(c)
-        s += c[j] * equations(kernel, x, xis[j])
-    end
-    return s
+function (diff_op_or_pde::DifferentialOperatorOrEquation)(itp::Interpolation, x)
+    return diff_op_or_pde(zero(eltype(x)), itp, x)
 end
 
-function (equations::AbstractTimeDependentEquation)(itp::Interpolation{<:LagrangeBasis},
-                                                    x)
-    c = kernel_coefficients(itp)
-    bas = basis(itp)
-    s = zero(eltype(x))
-    for j in eachindex(c)
-        s += c[j] * equations(bas[j], x)
-    end
-    return s
+function (diff_op_or_pde::DifferentialOperatorOrEquation)(itp::Interpolation{<:LagrangeBasis},
+                                                          x)
+    return diff_op_or_pde(zero(eltype(x)), itp, x)
 end
 
 function (g::Gradient)(itp::Interpolation, x)
-    kernel = interpolation_kernel(itp)
-    xis = centers(itp)
-    c = kernel_coefficients(itp)
-    s = zero(x)
-    for j in eachindex(c)
-        s += c[j] * g(kernel, x, xis[j])
-    end
-    return s
+    return g(zero(x), itp, x)
 end
 
 function (g::Gradient)(itp::Interpolation{<:LagrangeBasis}, x)
-    c = kernel_coefficients(itp)
-    bas = basis(itp)
-    s = zero(x)
-    for j in eachindex(c)
-        s += c[j] * g(bas[j], x)
-    end
-    return s
+    return g(zero(x), itp, x)
 end
 
 # TODO: Does this also make sense for conditionally positive definite kernels?

--- a/src/interpolation.jl
+++ b/src/interpolation.jl
@@ -251,6 +251,17 @@ function (diff_op_or_pde::Union{AbstractDifferentialOperator, AbstractStationary
     return s
 end
 
+function (equations::AbstractTimeDependentEquation)(itp::Interpolation, x)
+    kernel = interpolation_kernel(itp)
+    xis = centers(itp)
+    c = kernel_coefficients(itp)
+    s = zero(eltype(x))
+    for j in eachindex(c)
+        s += c[j] * equations(kernel, x, xis[j])
+    end
+    return s
+end
+
 function (g::Gradient)(itp::Interpolation, x)
     kernel = interpolation_kernel(itp)
     xis = centers(itp)
@@ -331,14 +342,12 @@ function (titp::TemporalInterpolation)(t)
     ode_sol = titp.ode_sol
     semi = ode_sol.prob.p
     @unpack nodeset_inner, boundary_condition, nodeset_boundary, basis = semi.spatial_discretization
-    @unpack centers, kernel = basis
     c = ode_sol(t)
     # Do not support additional polynomial basis for now
     xx = polyvars(dim(semi))
     ps = monomials(xx, 0:-1)
     nodeset = merge(nodeset_inner, nodeset_boundary)
-    itp = Interpolation(StandardBasis(centers, kernel), nodeset, c,
-                        semi.cache.mass_matrix, ps, xx)
+    itp = Interpolation(basis, nodeset, c, semi.cache.mass_matrix, ps, xx)
     return itp
 end
 

--- a/src/interpolation.jl
+++ b/src/interpolation.jl
@@ -284,6 +284,16 @@ function (g::Gradient)(itp::Interpolation, x)
     return s
 end
 
+function (g::Gradient)(itp::Interpolation{<:LagrangeBasis}, x)
+    c = kernel_coefficients(itp)
+    bas = basis(itp)
+    s = zero(x)
+    for j in eachindex(c)
+        s += c[j] * g(bas[j], x)
+    end
+    return s
+end
+
 # TODO: Does this also make sense for conditionally positive definite kernels?
 @doc raw"""
     kernel_inner_product(itp1, itp2)

--- a/src/interpolation.jl
+++ b/src/interpolation.jl
@@ -262,6 +262,17 @@ function (equations::AbstractTimeDependentEquation)(itp::Interpolation, x)
     return s
 end
 
+function (equations::AbstractTimeDependentEquation)(itp::Interpolation{<:LagrangeBasis},
+                                                    x)
+    c = kernel_coefficients(itp)
+    bas = basis(itp)
+    s = zero(eltype(x))
+    for j in eachindex(c)
+        s += c[j] * equations(bas[j], x)
+    end
+    return s
+end
+
 function (g::Gradient)(itp::Interpolation, x)
     kernel = interpolation_kernel(itp)
     xis = centers(itp)

--- a/src/kernel_matrices.jl
+++ b/src/kernel_matrices.jl
@@ -157,13 +157,18 @@ end
 
 @doc raw"""
     pde_matrix(diff_op_or_pde, nodeset1, nodeset2, kernel)
+    pde_matrix(diff_op_or_pde, nodeset, basis)
 
 Compute the matrix of a partial differential equation (or differential operator) with a given kernel. The matrix is defined as
 ```math
     (\tilde A_\mathcal{L})_{ij} = \mathcal{L}K(x_i, \xi_j),
 ```
 where ``\mathcal{L}`` is the differential operator (defined by the `equations`), ``K`` the `kernel`, ``x_i`` are the nodes
-in `nodeset1` and ``\xi_j`` are the nodes in `nodeset2`.
+in `nodeset1` and ``\xi_j`` are the nodes in `nodeset2`. If a `basis` is given, the matrix is defined as
+```math
+    (\tilde A_\mathcal{L})_{ij} = \mathcal{L}b_j(x_i),
+```
+where ``b_j`` are the basis functions in the `basis` and ``x_i`` are the nodes in `nodeset`.
 """
 function pde_matrix(diff_op_or_pde, nodeset1, nodeset2, kernel)
     n = length(nodeset1)
@@ -177,8 +182,27 @@ function pde_matrix(diff_op_or_pde, nodeset1, nodeset2, kernel)
     return A
 end
 
+function pde_matrix(diff_op_or_pde, nodeset::NodeSet, basis::LagrangeBasis)
+    n = length(nodeset)
+    m = length(basis)
+    A = Matrix{eltype(nodeset)}(undef, n, m)
+    basis_functions = collect(basis)
+    for i in eachindex(nodeset)
+        x_i = nodeset[i]
+        for j in eachindex(basis_functions)
+            A[i, j] = diff_op_or_pde(basis_functions[j], x_i)
+        end
+    end
+    return A
+end
+
+function pde_matrix(diff_op_or_pde, nodeset::NodeSet, basis::StandardBasis)
+    return pde_matrix(diff_op_or_pde, nodeset, centers(basis), interpolation_kernel(basis))
+end
+
 @doc raw"""
     pde_boundary_matrix(diff_op_or_pde, nodeset_inner, nodeset_boundary, [centers,] kernel)
+    pde_boundary_matrix(diff_op_or_pde, nodeset_inner, nodeset_boundary, basis)
 
 Compute the matrix of a partial differential equation (or differential operator) with a given kernel. The matrix is defined as
 ```math
@@ -194,6 +218,14 @@ and ``\tilde A`` is the kernel matrix for the boundary nodes:
 ```
 where ``\mathcal{L}`` is the differential operator (defined by the `equations`), ``K`` the `kernel`, ``x_i`` are the nodes
 in `nodeset_boundary` and ``\xi_j`` are the `centers`. By default, `centers` is set to `merge(nodeset_inner, nodeset_boundary)`.
+If a `basis` is given, the matrices are defined as
+```math
+    (\tilde A_\mathcal{L})_{ij} = \mathcal{L}b_j(x_i),
+```and ``\tilde A`` is the kernel matrix for the boundary nodes:
+```math
+    \tilde A_{ij} = b_j(x_i),
+```
+where ``\mathcal{L}`` is the differential operator (defined by the `equations`), ``b_j`` the basis functions in the `basis`, and ``x_i`` are the nodes in `nodeset_boundary`.
 
 See also [`pde_matrix`](@ref) and [`kernel_matrix`](@ref).
 """
@@ -205,12 +237,21 @@ function pde_boundary_matrix(diff_op_or_pde, nodeset_inner, nodeset_boundary, ce
             b_matrix]
 end
 
+function pde_boundary_matrix(diff_op_or_pde, nodeset_inner, nodeset_boundary,
+                             basis::AbstractBasis)
+    pd_matrix = pde_matrix(diff_op_or_pde, nodeset_inner, basis)
+    b_matrix = kernel_matrix(basis, nodeset_boundary)
+    return [pd_matrix
+            b_matrix]
+end
+
 function pde_boundary_matrix(diff_op_or_pde, nodeset_inner, nodeset_boundary, kernel)
     return pde_boundary_matrix(diff_op_or_pde, nodeset_inner, nodeset_boundary,
                                merge(nodeset_inner, nodeset_boundary), kernel)
 end
 
 @doc raw"""
+    operator_matrix(diff_op_or_pde, nodeset_inner, nodeset_boundary, basis)
     operator_matrix(diff_op_or_pde, nodeset_inner, nodeset_boundary, kernel)
 
 Compute the operator matrix ``L`` discretizing ``\mathcal{L}`` for a given kernel. The operator matrix is defined as
@@ -218,12 +259,21 @@ Compute the operator matrix ``L`` discretizing ``\mathcal{L}`` for a given kerne
     L = A_\mathcal{L} A^{-1},
 ```
 where ``A_\mathcal{L}`` is the matrix of the differential operator (defined by the `equations`), and ``A`` the kernel matrix.
+If a `basis` is passed, `A` is built via [`kernel_matrix`](@ref) for that basis on
+`merge(nodeset_inner, nodeset_boundary)` and ``A_\mathcal{L}`` via
+[`pde_boundary_matrix`](@ref) for the same basis.
 
 See also [`pde_boundary_matrix`](@ref) and [`kernel_matrix`](@ref).
 """
-function operator_matrix(diff_op_or_pde, nodeset_inner, nodeset_boundary, kernel)
+function operator_matrix(diff_op_or_pde, nodeset_inner, nodeset_boundary,
+                         basis::AbstractBasis)
     nodeset = merge(nodeset_inner, nodeset_boundary)
-    A = kernel_matrix(nodeset, kernel)
-    A_L = pde_boundary_matrix(diff_op_or_pde, nodeset_inner, nodeset_boundary, kernel)
+    A = kernel_matrix(basis, nodeset)
+    A_L = pde_boundary_matrix(diff_op_or_pde, nodeset_inner, nodeset_boundary, basis)
     return A_L / A
+end
+
+function operator_matrix(diff_op_or_pde, nodeset_inner, nodeset_boundary, kernel)
+    basis = StandardBasis(merge(nodeset_inner, nodeset_boundary), kernel)
+    return operator_matrix(diff_op_or_pde, nodeset_inner, nodeset_boundary, basis)
 end

--- a/test/test_examples_pde.jl
+++ b/test/test_examples_pde.jl
@@ -13,8 +13,8 @@ end
 
 @testitem "poisson_2d_lagrange_basis.jl" setup=[Setup, AdditionalImports, PDEExamples] begin
     @test_include_example(joinpath(EXAMPLES_DIR, "poisson_2d_lagrange_basis.jl"),
-                          l2=0.05189287444793586, linf=0.00962327274766674,
-                          pde_test=true, atol=1e-7)
+                          l2=0.0760581870219309, linf=0.011540352885859195,
+                          pde_test=true)
 end
 
 @testitem "laplace_2d_annulus.jl" setup=[Setup, AdditionalImports, PDEExamples] begin
@@ -49,8 +49,8 @@ end
 
 @testitem "heat_2d_lagrange_basis.jl" setup=[Setup, AdditionalImports, PDEExamples] begin
     @test_include_example(joinpath(EXAMPLES_DIR, "heat_2d_lagrange_basis.jl"),
-                          l2=0.05146353759212834, linf=0.005234206537239573,
-                          pde_test=true, atol=1e-8)
+                          l2=0.04845861406406618, linf=0.0049142944777497075,
+                          pde_test=true)
 end
 
 @testitem "advection_1d_basic.jl" setup=[Setup, AdditionalImports, PDEExamples] begin

--- a/test/test_examples_pde.jl
+++ b/test/test_examples_pde.jl
@@ -14,7 +14,7 @@ end
 @testitem "poisson_2d_lagrange_basis.jl" setup=[Setup, AdditionalImports, PDEExamples] begin
     @test_include_example(joinpath(EXAMPLES_DIR, "poisson_2d_lagrange_basis.jl"),
                           l2=0.05189287444793586, linf=0.00962327274766674,
-                          pde_test=true)
+                          pde_test=true, atol=1e-9)
 end
 
 @testitem "laplace_2d_annulus.jl" setup=[Setup, AdditionalImports, PDEExamples] begin
@@ -50,7 +50,7 @@ end
 @testitem "heat_2d_lagrange_basis.jl" setup=[Setup, AdditionalImports, PDEExamples] begin
     @test_include_example(joinpath(EXAMPLES_DIR, "heat_2d_lagrange_basis.jl"),
                           l2=0.05146361882764055, linf=0.00523420203740077,
-                          pde_test=true)
+                          pde_test=true, atol=1e-8)
 end
 
 @testitem "advection_1d_basic.jl" setup=[Setup, AdditionalImports, PDEExamples] begin

--- a/test/test_examples_pde.jl
+++ b/test/test_examples_pde.jl
@@ -14,7 +14,7 @@ end
 @testitem "poisson_2d_lagrange_basis.jl" setup=[Setup, AdditionalImports, PDEExamples] begin
     @test_include_example(joinpath(EXAMPLES_DIR, "poisson_2d_lagrange_basis.jl"),
                           l2=0.05189287444793586, linf=0.00962327274766674,
-                          pde_test=true, atol=1e-9)
+                          pde_test=true, atol=1e-7)
 end
 
 @testitem "laplace_2d_annulus.jl" setup=[Setup, AdditionalImports, PDEExamples] begin

--- a/test/test_examples_pde.jl
+++ b/test/test_examples_pde.jl
@@ -11,6 +11,12 @@ end
                           pde_test=true)
 end
 
+@testitem "poisson_2d_lagrange_basis.jl" setup=[Setup, AdditionalImports, PDEExamples] begin
+    @test_include_example(joinpath(EXAMPLES_DIR, "poisson_2d_lagrange_basis.jl"),
+                          l2=0.05189287444793586, linf=0.00962327274766674,
+                          pde_test=true)
+end
+
 @testitem "laplace_2d_annulus.jl" setup=[Setup, AdditionalImports, PDEExamples] begin
     # No analytical solution available (don't compare l2 and linf norms)
     @test_include_example(joinpath(EXAMPLES_DIR, "laplace_2d_annulus.jl"),

--- a/test/test_examples_pde.jl
+++ b/test/test_examples_pde.jl
@@ -49,8 +49,8 @@ end
 
 @testitem "heat_2d_lagrange_basis.jl" setup=[Setup, AdditionalImports, PDEExamples] begin
     @test_include_example(joinpath(EXAMPLES_DIR, "heat_2d_lagrange_basis.jl"),
-                          l2=0.05146361882764055, linf=0.00523420203740077,
-                          pde_test=true, atol=1e-8)
+                          l2=0.05146353759212834, linf=0.005234206537239573,
+                          pde_test=true)
 end
 
 @testitem "advection_1d_basic.jl" setup=[Setup, AdditionalImports, PDEExamples] begin

--- a/test/test_examples_pde.jl
+++ b/test/test_examples_pde.jl
@@ -49,6 +49,7 @@ end
 
 @testitem "heat_2d_lagrange_basis.jl" setup=[Setup, AdditionalImports, PDEExamples] begin
     @test_include_example(joinpath(EXAMPLES_DIR, "heat_2d_lagrange_basis.jl"),
+                          l2=0.05146361882764055, linf=0.00523420203740077,
                           pde_test=true)
 end
 

--- a/test/test_examples_pde.jl
+++ b/test/test_examples_pde.jl
@@ -50,7 +50,7 @@ end
 @testitem "heat_2d_lagrange_basis.jl" setup=[Setup, AdditionalImports, PDEExamples] begin
     @test_include_example(joinpath(EXAMPLES_DIR, "heat_2d_lagrange_basis.jl"),
                           l2=0.05146353759212834, linf=0.005234206537239573,
-                          pde_test=true)
+                          pde_test=true, atol=1e-8)
 end
 
 @testitem "advection_1d_basic.jl" setup=[Setup, AdditionalImports, PDEExamples] begin

--- a/test/test_examples_pde.jl
+++ b/test/test_examples_pde.jl
@@ -13,8 +13,8 @@ end
 
 @testitem "poisson_2d_lagrange_basis.jl" setup=[Setup, AdditionalImports, PDEExamples] begin
     @test_include_example(joinpath(EXAMPLES_DIR, "poisson_2d_lagrange_basis.jl"),
-                          l2=0.0760581870219309, linf=0.011540352885859195,
-                          pde_test=true)
+                          l2=0.05189287444793586, linf=0.00962327274766674,
+                          pde_test=true, atol=1e-7)
 end
 
 @testitem "laplace_2d_annulus.jl" setup=[Setup, AdditionalImports, PDEExamples] begin
@@ -49,8 +49,8 @@ end
 
 @testitem "heat_2d_lagrange_basis.jl" setup=[Setup, AdditionalImports, PDEExamples] begin
     @test_include_example(joinpath(EXAMPLES_DIR, "heat_2d_lagrange_basis.jl"),
-                          l2=0.04845861406406618, linf=0.0049142944777497075,
-                          pde_test=true)
+                          l2=0.05146353759212834, linf=0.005234206537239573,
+                          pde_test=true, atol=1e-8)
 end
 
 @testitem "advection_1d_basic.jl" setup=[Setup, AdditionalImports, PDEExamples] begin

--- a/test/test_examples_pde.jl
+++ b/test/test_examples_pde.jl
@@ -47,6 +47,11 @@ end
                           pde_test=true)
 end
 
+@testitem "heat_2d_lagrange_basis.jl" setup=[Setup, AdditionalImports, PDEExamples] begin
+    @test_include_example(joinpath(EXAMPLES_DIR, "heat_2d_lagrange_basis.jl"),
+                          pde_test=true)
+end
+
 @testitem "advection_1d_basic.jl" setup=[Setup, AdditionalImports, PDEExamples] begin
     @test_include_example(joinpath(EXAMPLES_DIR, "advection_1d_basic.jl"),
                           l2=0.026436141175788297, linf=0.004194649552604207,

--- a/test/test_unit.jl
+++ b/test/test_unit.jl
@@ -1082,7 +1082,7 @@ end
     itp_lagrange = @test_nowarn solve_stationary(sd_lagrange)
 
     for node in nodeset_inner
-        @test isapprox(pde(itp_lagrange, node), f1(node, pde), atol = 1e-14)
+        @test isapprox(pde(itp_lagrange, node), f1(node, pde), atol = 1e-13)
     end
     for (node, value) in zip(nodeset_boundary, g1.(nodeset_boundary))
         @test isapprox(itp_lagrange(node), value, atol = 1e-14)

--- a/test/test_unit.jl
+++ b/test/test_unit.jl
@@ -840,6 +840,32 @@ end
         @test isapprox(g_itp[i][1], d1_itp[i])
     end
 
+    # Gradient with LagrangeBasis
+    nodes_2d = NodeSet([0.0 0.0
+                        1.0 0.0
+                        0.0 1.0
+                        1.0 1.0])
+    f_2d(x) = x[1]^2 + x[2]^2
+    ff_2d = f_2d.(nodes_2d)
+    kernel_2d = GaussKernel{2}(shape_parameter = 1.0)
+    basis_lagrange = @test_nowarn LagrangeBasis(nodes_2d, kernel_2d)
+    itp_lagrange = @test_nowarn interpolate(basis_lagrange, ff_2d)
+
+    g = @test_nowarn Gradient()
+    d2 = @test_nowarn PartialDerivative(2)
+    test_points = NodeSet([0.25 0.25
+                           0.75 0.25
+                           0.25 0.75
+                           0.75 0.75])
+    g_itp_lagrange = @test_nowarn g.(Ref(itp_lagrange), test_points)
+    d1_itp_lagrange = @test_nowarn d1.(Ref(itp_lagrange), test_points)
+    d2_itp_lagrange = @test_nowarn d2.(Ref(itp_lagrange), test_points)
+
+    for i in eachindex(test_points)
+        @test isapprox(g_itp_lagrange[i][1], d1_itp_lagrange[i])
+        @test isapprox(g_itp_lagrange[i][2], d2_itp_lagrange[i])
+    end
+
     # TODO: test convergence orders of condition numbers depending on separation distance
 end
 

--- a/test/test_unit.jl
+++ b/test/test_unit.jl
@@ -1204,6 +1204,51 @@ end
     @test typeof(@inferred itp([0.5f0, 0.5f0])) == Float32
 end
 
+@testitem "Kernel-based pde_boundary_matrix" setup=[Setup, AdditionalImports] begin
+    using KernelInterpolation: pde_boundary_matrix
+    # Setup from "solving PDEs" test
+    nodeset_inner = NodeSet([0.25 0.25
+                             0.75 0.25
+                             0.25 0.75
+                             0.75 0.75])
+    nodeset_boundary = NodeSet([0.0 0.0
+                                1.0 0.0
+                                0.0 1.0
+                                1.0 1.0])
+    kernel = Matern52Kernel{2}(shape_parameter = 0.5)
+    u1(x) = x[1] * (x[1] - 1.0) + (x[2] - 1.0) * x[2]
+    f1(x, equations) = -4.0 # -Δu
+    pde = PoissonEquation(f1)
+
+    # Call pde_boundary_matrix with explicit centers and kernel
+    centers_explicit = merge(nodeset_inner, nodeset_boundary)
+    pdeb_matrix_explicit = pde_boundary_matrix(pde, nodeset_inner, nodeset_boundary,
+                                               centers_explicit, kernel)
+
+    # Call pde_boundary_matrix with just kernel (computes centers internally)
+    pdeb_matrix_implicit = pde_boundary_matrix(pde, nodeset_inner, nodeset_boundary, kernel)
+
+    # Verify both produce the same result
+    @test pdeb_matrix_explicit ≈ pdeb_matrix_implicit
+
+    # Verify they match the basis-aware version with StandardBasis
+    standard_basis = StandardBasis(merge(nodeset_inner, nodeset_boundary), kernel)
+    pdeb_matrix_basis = pde_boundary_matrix(pde, nodeset_inner, nodeset_boundary,
+                                            standard_basis)
+    @test pdeb_matrix_implicit ≈ pdeb_matrix_basis
+
+    # Verify matrix shape and structure (4 inner + 4 boundary = 8 rows total)
+    @test size(pdeb_matrix_explicit) == (8, 8)
+    @test size(pdeb_matrix_implicit) == (8, 8)
+    @test size(pdeb_matrix_basis) == (8, 8)
+
+    # Verify correctness by checking operator_matrix still works with kernel
+    # and produces same result as basis version
+    L_kernel = operator_matrix(pde, nodeset_inner, nodeset_boundary, kernel)
+    L_basis = operator_matrix(pde, nodeset_inner, nodeset_boundary, standard_basis)
+    @test L_kernel ≈ L_basis
+end
+
 @testitem "Callbacks" setup=[Setup, AdditionalImports] begin
     # AliveCallback
     alive_callback = AliveCallback(dt = 0.1)

--- a/test/test_unit.jl
+++ b/test/test_unit.jl
@@ -1075,9 +1075,31 @@ end
     x = [0.1, 0.08]
     @test isapprox(itp(x), u1(x), atol = 0.12)
 
+    # stationary PDE with LagrangeBasis
+    lagrange_basis = LagrangeBasis(merge(nodeset_inner, nodeset_boundary), kernel)
+    sd_lagrange = SpatialDiscretization(pde, nodeset_inner, g1, nodeset_boundary,
+                                        lagrange_basis)
+    itp_lagrange = @test_nowarn solve_stationary(sd_lagrange)
+
+    for node in nodeset_inner
+        @test isapprox(pde(itp_lagrange, node), f1(node, pde), atol = 1e-14)
+    end
+    for (node, value) in zip(nodeset_boundary, g1.(nodeset_boundary))
+        @test isapprox(itp_lagrange(node), value, atol = 1e-14)
+    end
+    @test isapprox(itp_lagrange(x), u1(x), atol = 0.12)
+    # Test if L * u = b also works with LagrangeBasis
+    nodes_lagrange = nodeset(itp_lagrange)
+    u_lagrange_values = itp_lagrange.(nodes_lagrange)
+    L_lagrange = operator_matrix(pde, nodeset_inner, nodeset_boundary, lagrange_basis)
+    b_lagrange_test = L_lagrange * u_lagrange_values
+    for (b_val, b_test_val) in zip(b, b_lagrange_test)
+        @test isapprox(b_val, b_test_val, atol = 1e-12)
+    end
+
     # time-dependent PDE
     u2(t, x, equations) = x[1] * (x[1] - 1.0) + (x[2] - 1.0) * x[2] + t
-    f2(t, x, equations) = -3.0 # ∂_t u -Δu
+    f2(t, x, equations) = -3.0 # ∂_t u - Δu
     pde = HeatEquation(2.0, f2)
     g2(t, x) = u2(t, x, pde)
     semi = Semidiscretization(pde, nodeset_inner, g2, nodeset_boundary, u2, kernel)


### PR DESCRIPTION
This allows to use a `LagrangeBasis` when solving PDEs.