### PR TITLE
Add benchmarks

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,27 @@
+name: Benchmark this PR
+on:
+  pull_request_target:
+    branches: [ main ]  # change to your default branch
+    paths-ignore:
+      - 'CITATION.bib'
+      - 'LICENSE.md'
+      - 'README.md'
+      - '.zenodo.json'
+      - '.github/workflows/CompatHelper.yml'
+      - '.github/workflows/Documenter.yml'
+      - '.github/workflows/Format-check.yml'
+      - '.github/workflows/TagBot.yml'
+      - '.github/workflows/SpellCheck.yml'
+      - '.github/workflows/JET.yml'
+      - 'docs/**'
+permissions:
+  pull-requests: write    # action needs to post a comment
+
+jobs:
+  bench:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: MilesCranmer/AirspeedVelocity.jl@action-v1
+        with:
+          julia-version: '1.10'
+          bench-on: ${{ github.event.pull_request.head.sha }}

--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -1,0 +1,5 @@
+[deps]
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+
+[compat]
+BenchmarkTools = "1"

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,0 +1,6 @@
+# Benchmarks
+
+This directory contains some benchmark setups using [BenchmarkTools.jl](https://github.com/JuliaCI/BenchmarkTools.jl).
+The file `benchmarks.jl` is run by a GitHub Action leveraging [AirspeedVelocity.jl](https://github.com/MilesCranmer/AirspeedVelocity.jl)
+to generate a report on the performance of the package for each pull request. If you want to run the benchmarks locally, you can do so by running
+`run_benchmarks.jl`, which returns a summary `results` of the benchmark results.

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,0 +1,12 @@
+using BenchmarkTools
+using KernelInterpolation
+
+const SUITE = BenchmarkGroup()
+
+f(x) = sin(sum(x))
+
+nodeset = NodeSet(LinRange(0.0, 2 * pi, 8))
+values = f.(nodeset)
+kernel = GaussKernel{dim(nodeset)}(shape_parameter = 0.5)
+
+SUITE["interpolation 1D"] = @benchmarkable interpolate($nodeset, $values, $kernel)

--- a/benchmark/run_benchmarks.jl
+++ b/benchmark/run_benchmarks.jl
@@ -1,0 +1,8 @@
+using Pkg
+Pkg.activate(@__DIR__)
+Pkg.develop(PackageSpec(path = dirname(@__DIR__)))
+Pkg.instantiate()
+
+include("benchmarks.jl")
+tune!(SUITE)
+result = run(SUITE)


### PR DESCRIPTION
Because the benchmark action is using `pull_request_target` instead of `pull_request`, this PR needs to be merged before it is run. So I'll add the remaining benchmarks in a subsequent PR.