### PR TITLE
Update coveralls action in CI workflow

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -80,6 +80,7 @@ jobs:
           parallel: true
           file: ./lcov.info
           format: lcov
+          debug: true
 
   finish:
     needs: test

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -80,7 +80,6 @@ jobs:
           parallel: true
           file: ./lcov.info
           format: lcov
-          debug: true
 
   finish:
     needs: test

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -78,7 +78,8 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           flag-name: run-${{ join(matrix.*, '-') }}
           parallel: true
-          path-to-lcov: ./lcov.info
+          file: ./lcov.info
+          format: lcov
 
   finish:
     needs: test


### PR DESCRIPTION
The coveralls GitHub action does not run anymore. We had the same in Trixi.jl, which seems to have been fixed by https://github.com/trixi-framework/Trixi.jl/pull/3086. So let's try the same here.