### PR TITLE
Speed up construction of LagrangeBasis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,13 +24,13 @@ for human readability.
 
 #### Changed
 
-- Speed up RBF-FD stencil selection (`KNearestNeighbors`, `RadiusSearch`) by using a `KDTree`
-  from NearestNeighbors.jl instead of a brute-force `O(N^2)` distance scan, reducing the overall
-  neighborhood search to roughly `O(N log N)` ([#189]).
 - Speed up `LagrangeBasis` construction (and hence also the RBF-FD `RBFFDLagrangeBasis` cache) by
   assembling and factorizing the augmented interpolation matrix once per node set and solving
   for all cardinal functions with a single multiple-right-hand-side solve, instead of
   re-assembling and re-factorizing it for each cardinal function ([#190]).
+- Speed up RBF-FD stencil selection (`KNearestNeighbors`, `RadiusSearch`) by using a `KDTree`
+  from NearestNeighbors.jl instead of a brute-force `O(N^2)` distance scan, reducing the overall
+  neighborhood search to roughly `O(N log N)` ([#189]).
 - Define slicing for `NodeSet`s and deprecate `values_along_dim` ([#139]).
 - Fix order of `PolyharmonicSplineKernel` to return an integer ([#127]).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ for human readability.
 - Speed up RBF-FD stencil selection (`KNearestNeighbors`, `RadiusSearch`) by using a `KDTree`
   from NearestNeighbors.jl instead of a brute-force `O(N^2)` distance scan, reducing the overall
   neighborhood search to roughly `O(N log N)` ([#189]).
+- Speed up `LagrangeBasis` construction (and hence also the RBF-FD `RBFFDLagrangeBasis` cache) by
+  assembling and factorizing the augmented interpolation matrix once per node set and solving
+  for all cardinal functions with a single multiple-right-hand-side solve, instead of
+  re-assembling and re-factorizing it for each cardinal function ([#190]).
 - Define slicing for `NodeSet`s and deprecate `values_along_dim` ([#139]).
 - Fix order of `PolyharmonicSplineKernel` to return an integer ([#127]).
 

--- a/src/basis.jl
+++ b/src/basis.jl
@@ -98,23 +98,28 @@ struct LagrangeBasis{Dim, RealT, Kernel, I <: AbstractInterpolation} <: Abstract
             throw(DimensionMismatch("The dimension of the kernel and the centers must be the same"))
         end
         K = length(centers)
-        values = Vector{RealT}(undef, K)
-        fill!(values, zero(RealT))
-        values[1] = one(RealT)
         std_basis = StandardBasis(centers, kernel)
-        b = interpolate(std_basis, values; m = m)
-        basis_functions = Vector{typeof(b)}(undef, K)
-        basis_functions[1] = b
-        for i in 2:K
-            values[i - 1] = zero(RealT)
-            values[i] = one(RealT)
-            basis_functions[i] = interpolate(std_basis, values; m = m)
-        end
-        # The polynomials are baked into the cardinal functions (each is an `Interpolation`
-        # carrying its own polynomial basis), so no separate basis-level polynomials are
-        # stored; cf. `polynomial_basis(basis_functions[i])`.
-        return new{dim(centers), eltype(centers), typeof(kernel),
-                   eltype(basis_functions)}(centers, kernel, basis_functions)
+        xx = polyvars(Val(Dim))
+        ps = monomials(xx, 0:(m - 1))
+        q = length(ps)
+        # All `K` cardinal functions share the same augmented interpolation matrix and differ
+        # only in their right-hand side (the `i`-th unit vector). Assemble and factorize that
+        # matrix once and solve for all cardinal functions simultaneously with a multiple
+        # right-hand side, instead of re-assembling and re-factorizing it for each one.
+        system_matrix = interpolation_matrix(std_basis, ps)
+        rhs = [Matrix{RealT}(I, K, K); zeros(RealT, q, K)]
+        coefficients = factorize(system_matrix) \ rhs
+        # Each cardinal function is an `Interpolation` sharing the same `system_matrix`. The
+        # polynomials are baked into the cardinal functions (each carries its own polynomial
+        # basis), so no separate basis-level polynomials are stored; cf.
+        # `polynomial_basis(basis_functions[i])`.
+        Itp = Interpolation{typeof(std_basis), Dim, RealT, typeof(system_matrix),
+                            typeof(ps), typeof(xx)}
+        basis_functions = [Itp(std_basis, centers, coefficients[:, i], system_matrix, ps,
+                               xx)
+                           for i in 1:K]
+        return new{Dim, RealT, Kernel, eltype(basis_functions)}(centers, kernel,
+                                                                basis_functions)
     end
 end
 

--- a/test/test_examples_pde.jl
+++ b/test/test_examples_pde.jl
@@ -60,7 +60,7 @@ end
 
 @testitem "heat_2d_lagrange_basis.jl" setup=[Setup, AdditionalImports, PDEExamples] begin
     @test_include_example(joinpath(EXAMPLES_DIR, "heat_2d_lagrange_basis.jl"),
-                          l2=0.05146353759212834, linf=0.005234206537239573,
+                          l2=0.0514635252933050, linf=0.00523420529895294,
                           pde_test=true, atol=1e-8)
 end
 


### PR DESCRIPTION
Instead of calling `interpolate` K times each time assembling the same matrices and solving several linear systems, we can compute the Lagrange basis directly by using a matrix RHS (basically the identity matrix) to speed up the construction significantly.