### PR TITLE
Several performance improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ for human readability.
 
 #### Changed
 
+- Several performance improvements reducing allocations, using threaded loops, using `KDTree` for nearest-neighbor searches, and computing the separation distance lazily ([#191]).
 - Speed up `LagrangeBasis` construction (and hence also the RBF-FD `RBFFDLagrangeBasis` cache) by
   assembling and factorizing the augmented interpolation matrix once per node set and solving
   for all cardinal functions with a single multiple-right-hand-side solve, instead of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,8 @@ for human readability.
 
 #### Changed
 
-- Several performance improvements reducing allocations, using threaded loops, using `KDTree` for nearest-neighbor searches, and computing the separation distance lazily ([#191]).
+- Several performance improvements reducing allocations, using threaded loops, using `KDTree`
+  for nearest-neighbor searches, and computing the separation distance lazily ([#191]).
 - Speed up `LagrangeBasis` construction (and hence also the RBF-FD `RBFFDLagrangeBasis` cache) by
   assembling and factorizing the augmented interpolation matrix once per node set and solving
   for all cardinal functions with a single multiple-right-hand-side solve, instead of

--- a/examples/PDEs/advection_3d_basic.jl
+++ b/examples/PDEs/advection_3d_basic.jl
@@ -1,15 +1,17 @@
 using KernelInterpolation
 using OrdinaryDiffEqRosenbrock, OrdinaryDiffEqNonlinearSolve
-using LinearAlgebra: norm
 using WriteVTK: WriteVTK, paraview_collection
 
 # source term of advection equation
 f(t, x, equations) = 0.0
 pde = AdvectionEquation((0.5, 0.5, 0.5), f)
 
-# initial condition
+# initial condition. Written component-wise (instead of with `norm` and a vector literal) so
+# it is allocation-free.
 function u(t, x, equations)
-    return exp(-20.0 * norm(x .- equations.advection_velocity .* t .- [0.3, 0.3, 0.3])^2)
+    v = equations.advection_velocity
+    return exp(-20.0 * ((x[1] - v[1] * t - 0.3)^2 + (x[2] - v[2] * t - 0.3)^2 +
+                (x[3] - v[3] * t - 0.3)^2))
 end
 
 n = 10

--- a/examples/PDEs/advection_diffusion_2d_basic.jl
+++ b/examples/PDEs/advection_diffusion_2d_basic.jl
@@ -1,14 +1,14 @@
 using KernelInterpolation
 using OrdinaryDiffEqRosenbrock, OrdinaryDiffEqNonlinearSolve
-using LinearAlgebra: norm
 using Plots
 
 # right-hand-side of advection diffusion equation
 f(t, x, equations) = 0.0
 pde = AdvectionDiffusionEquation(0.01, (0.2, 0.7), f)
 
-# initial condition
-u(t, x, equations) = exp(-100.0 * norm(x - [0.4, 0.5])^2)
+# initial condition. Written component-wise (instead of with `norm` and a vector literal) so
+# it is allocation-free.
+u(t, x, equations) = exp(-100.0 * ((x[1] - 0.4)^2 + (x[2] - 0.5)^2))
 
 n = 15
 nodeset_inner = homogeneous_hypercube(n, (0.1, 0.1), (0.9, 1.9); dim = 2)

--- a/examples/PDEs/rbf_fd_advection_2d_basic.jl
+++ b/examples/PDEs/rbf_fd_advection_2d_basic.jl
@@ -1,15 +1,17 @@
 using KernelInterpolation
 using OrdinaryDiffEqRosenbrock, OrdinaryDiffEqNonlinearSolve
-using LinearAlgebra: norm
 using Plots
 
 # source term of advection equation
 f(t, x, equations) = 0.0
 pde = AdvectionEquation((0.5, 0.5), f)
 
-# initial condition (also used as analytical solution)
+# initial condition (also used as analytical solution). Written component-wise (instead of
+# with `norm` and a vector literal) so it is allocation-free in the hot boundary-condition
+# evaluation `g`.
 function u(t, x, equations)
-    return exp(-20.0 * norm(x .- equations.advection_velocity .* t .- [0.3, 0.3])^2)
+    v = equations.advection_velocity
+    return exp(-20.0 * ((x[1] - v[1] * t - 0.3)^2 + (x[2] - v[2] * t - 0.3)^2))
 end
 
 n = 15
@@ -17,7 +19,11 @@ nodeset_inner = homogeneous_hypercube(n, 0.01, 1.0; dim = 2)
 # only provide boundary condition on the inflow boundaries (left and bottom)
 nodeset_boundary = NodeSet(union([[0.0, y] for y in LinRange(0.0, 1.0, n)],
                                  [[x, 0.0] for x in LinRange(0.0, 1.0, n)]))
-g(t, x) = u(t, x, pde)
+# Capture `pde` in the closure instead of referencing the non-const global, so the boundary
+# condition is type-stable and allocation-free when evaluated in the time-stepping loop.
+g = let pde = pde
+    (t, x) -> u(t, x, pde)
+end
 
 kernel = PolyharmonicSplineKernel{2}(3)
 local_basis = RBFFDLagrangeBasis()

--- a/src/KernelInterpolation.jl
+++ b/src/KernelInterpolation.jl
@@ -13,7 +13,7 @@ module KernelInterpolation
 
 using DiffEqCallbacks: PeriodicCallback, PeriodicCallbackAffect
 using ForwardDiff: ForwardDiff
-using LinearAlgebra: Diagonal, Symmetric, I, norm, tr, dot, diagind, factorize
+using LinearAlgebra: Diagonal, Symmetric, I, norm, tr, dot, diagind, factorize, mul!
 using NearestNeighbors: KDTree, knn, inrange
 using Printf: @sprintf
 using Random: Random

--- a/src/KernelInterpolation.jl
+++ b/src/KernelInterpolation.jl
@@ -14,7 +14,7 @@ module KernelInterpolation
 using DiffEqCallbacks: PeriodicCallback, PeriodicCallbackAffect
 using ForwardDiff: ForwardDiff
 using LinearAlgebra: Diagonal, Symmetric, I, norm, tr, dot, diagind, factorize, mul!
-using NearestNeighbors: KDTree, knn, inrange
+using NearestNeighbors: KDTree, inrange, knn, nn
 using Printf: @sprintf
 using Random: Random
 using ReadVTK: VTKFile, get_points, get_point_data, get_data

--- a/src/discretization.jl
+++ b/src/discretization.jl
@@ -320,15 +320,39 @@ function rhs!(dc, c, semi, t)
     @unpack pde_boundary_matrix = semi.cache
     @unpack equations, nodeset_inner, boundary_condition, nodeset_boundary = semi.spatial_discretization
     @trixi_timeit timer() "rhs!" begin
+        # Seed `dc` with the right-hand side b = (f; g) (source term at the inner nodes,
+        # boundary values at the boundary nodes). Writing into `dc` directly keeps `rhs!`
+        # allocation-free and works when a solver evaluates it with `ForwardDiff.Dual` numbers
+        # since `dc` already has the matching element type.
         @trixi_timeit timer() "rhs vector" begin
-            rhs_vector = [rhs(t, nodeset_inner, equations);
-                          boundary_condition.(Ref(t), nodeset_boundary)]
+            fill_rhs_vector!(dc, t, nodeset_inner, boundary_condition, nodeset_boundary,
+                             equations)
         end
-        # dc = -pde_boundary_matrix * c + rhs_vector
-        @trixi_timeit timer() "muladd" dc[:]=Base.muladd(pde_boundary_matrix, -c,
-                                                         rhs_vector)
+        # dc = -pde_boundary_matrix * c + dc, computed in place via a 5-argument `mul!`.
+        @trixi_timeit timer() "mul!" mul!(dc, pde_boundary_matrix, c, -1, true)
     end
     return nothing
+end
+
+# In-place assembly of the ODE right-hand side `b = (f; g)` (source term `f` at the inner
+# nodes, boundary values `g` at the boundary nodes) into `out`. This is the allocation-free
+# counterpart of `[rhs(t, nodeset_inner, equations); g.(...)]` used in the hot `rhs!`
+# time-stepping loop; `out` (the solver's `dc`) carries the appropriate element type.
+function fill_rhs_vector!(out, t, nodeset_inner, boundary_condition, nodeset_boundary,
+                          equations)
+    n_inner = length(nodeset_inner)
+    f = equations.f
+    if f isa AbstractVector
+        @views out[1:n_inner] .= f
+    else
+        for i in 1:n_inner
+            out[i] = f(t, nodeset_inner[i], equations)
+        end
+    end
+    for j in eachindex(nodeset_boundary)
+        out[n_inner + j] = boundary_condition(t, nodeset_boundary[j])
+    end
+    return out
 end
 
 """

--- a/src/kernel_matrices.jl
+++ b/src/kernel_matrices.jl
@@ -37,28 +37,6 @@ function kernel_matrix(nodeset::NodeSet, kernel::AbstractKernel)
 end
 
 """
-    nearest_node_index(y, nodeset)
-
-Return the index of the node in `nodeset` that is closest to `y` in Euclidean norm.
-"""
-function nearest_node_index(y::AbstractVector, nodeset::NodeSet)
-    n = length(nodeset)
-    n > 0 || throw(ArgumentError("nodeset must be non-empty"))
-
-    best_idx = 1
-    best_dist = norm(y .- nodeset[1])
-    for i in 2:n
-        d = norm(y .- nodeset[i])
-        if d < best_dist
-            best_dist = d
-            best_idx = i
-        end
-    end
-
-    return best_idx
-end
-
-"""
     polynomial_matrix(nodeset, ps)
 
 Return the polynomial matrix for the nodeset and polynomials. The polynomial matrix is defined as

--- a/src/kernel_matrices.jl
+++ b/src/kernel_matrices.jl
@@ -18,7 +18,8 @@ function kernel_matrix(basis::AbstractBasis, nodeset::NodeSet = centers(basis))
     n = length(nodeset)
     m = length(basis)
     A = Matrix{eltype(nodeset)}(undef, n, m)
-    for i in 1:n
+    # The rows are independent, so they are filled in parallel.
+    Threads.@threads for i in 1:n
         for j in 1:m
             A[i, j] = basis[j](nodeset[i])
         end
@@ -198,7 +199,8 @@ function pde_matrix(diff_op_or_pde, nodeset1, nodeset2, kernel)
     n = length(nodeset1)
     m = length(nodeset2)
     A = Matrix{eltype(nodeset1)}(undef, n, m)
-    for i in 1:n
+    # The rows are independent, so they are filled in parallel.
+    Threads.@threads for i in 1:n
         for j in 1:m
             A[i, j] = diff_op_or_pde(kernel, nodeset1[i], nodeset2[j])
         end
@@ -211,7 +213,8 @@ function pde_matrix(diff_op_or_pde, nodeset::NodeSet, basis::LagrangeBasis)
     m = length(basis)
     A = Matrix{eltype(nodeset)}(undef, n, m)
     basis_functions = collect(basis)
-    for i in eachindex(nodeset)
+    # The rows are independent, so they are filled in parallel.
+    Threads.@threads for i in 1:n
         x_i = nodeset[i]
         for j in eachindex(basis_functions)
             A[i, j] = diff_op_or_pde(basis_functions[j], x_i)

--- a/src/nodes.jl
+++ b/src/nodes.jl
@@ -10,7 +10,8 @@ end
 
 function Base.show(io::IO, nodeset::NodeSet)
     print(io, "NodeSet{", dim(nodeset), ", ", eltype(nodeset),
-          "} with separation distance q = ", nodeset.q, " and ", length(nodeset), " nodes")
+          "} with separation distance q = ", separation_distance(nodeset), " and ",
+          length(nodeset), " nodes")
     return nothing
 end
 
@@ -19,7 +20,8 @@ function Base.show(io::IO, ::MIME"text/plain", nodeset::NodeSet)
         show(io, nodeset)
     else
         println(io, "NodeSet{", dim(nodeset), ", ", eltype(nodeset), "} with ",
-                "separation distance q = ", nodeset.q, " and ", length(nodeset), " nodes:")
+                "separation distance q = ", separation_distance(nodeset), " and ",
+                length(nodeset), " nodes:")
         max_nodes = 20
         for i in 1:min(max_nodes, length(nodeset))
             if isassigned(nodeset, i)
@@ -36,9 +38,9 @@ end
 
 # Constructors
 function NodeSet(nodes::Vector{MVector{Dim, RealT}}) where {Dim, RealT}
-    q = separation_distance(nodes)
-    # Convert nodes to floats by design
-    return NodeSet{Dim, float(RealT)}(nodes, q)
+    # Convert nodes to floats by design. The separation distance `q` is computed lazily on
+    # first access (`NaN` marks it as not yet computed).
+    return NodeSet{Dim, float(RealT)}(nodes, convert(float(RealT), NaN))
 end
 function NodeSet(nodes::Vector{SVector{Dim, RealT}}) where {Dim, RealT}
     return NodeSet(MVector.(nodes))
@@ -70,19 +72,17 @@ NodeSet(nodeset::NodeSet) = nodeset
 Create an empty [`NodeSet`](@ref).
 """
 function empty_nodeset(Dim, RealT = Float64)
-    return NodeSet{Dim, RealT}(Vector{MVector{Dim, RealT}}[], Inf)
+    return NodeSet{Dim, RealT}(Vector{MVector{Dim, RealT}}[], convert(RealT, NaN))
 end
 
 function separation_distance(nodes::Vector{MVector{Dim, RealT}}) where {Dim, RealT}
-    r = Inf
-    for (i, x) in enumerate(nodes)
-        for (j, y) in enumerate(nodes)
-            if i != j && norm(x - y) < r
-                r = norm(x - y)
-            end
-        end
-    end
-    return 0.5 * r
+    length(nodes) < 2 && return convert(RealT, Inf)
+    tree = KDTree(nodes)
+    # k = 2: the nearest neighbor of each point is the point itself (distance 0); the second
+    # is the nearest distinct point, so the global minimum of those second distances is the
+    # minimal pairwise distance. This is `O(N log N)` instead of the brute-force `O(N^2)`.
+    _, distances = knn(tree, nodes, 2, true)
+    return convert(RealT, 0.5 * minimum(d -> d[2], distances))
 end
 
 @doc raw"""
@@ -93,13 +93,21 @@ Return the separation distance of a [`NodeSet`](@ref) ``X = \{x_1,\ldots, x_n\}`
     q_X = \frac{1}{2}\min_{x_i\neq x_j}\|x_i - x_j\|.
 ```
 """
-separation_distance(nodeset::NodeSet) = nodeset.q
-function update_separation_distance!(nodeset::NodeSet)
-    # Update separation distance only if all values are assigned to prevent `UndefRefError`
-    if all(map(i -> isassigned(nodeset, i), eachindex(nodeset)))
-        q = separation_distance(nodeset.nodes)
-        nodeset.q = q
+# The separation distance is computed lazily and cached in `nodeset.q`, with `NaN` marking a
+# stale/not-yet-computed value. It is (re)computed on first access after construction or a
+# mutation, and only when all nodes are assigned (to prevent `UndefRefError`).
+function separation_distance(nodeset::NodeSet)
+    if isnan(nodeset.q) && all(i -> isassigned(nodeset, i), eachindex(nodeset))
+        nodeset.q = separation_distance(nodeset.nodes)
     end
+    return nodeset.q
+end
+# Mark the cached separation distance as stale; it is recomputed lazily on the next
+# `separation_distance(nodeset)` access. This keeps mutations `O(1)` instead of recomputing
+# the (now `O(N log N)`) separation distance on every change.
+function update_separation_distance!(nodeset::NodeSet{Dim, RealT}) where {Dim, RealT}
+    nodeset.q = convert(RealT, NaN)
+    return nodeset
 end
 dim(::NodeSet{Dim, RealT}) where {Dim, RealT} = Dim
 # Equality based on node coordinates (not object identity); keep `hash` consistent with `==`.
@@ -117,16 +125,16 @@ Base.eachindex(nodeset::NodeSet) = eachindex(nodeset.nodes)
 eachdim(nodeset::NodeSet) = Base.OneTo(dim(nodeset))
 Base.isassigned(nodeset::NodeSet, i::Int) = isassigned(nodeset.nodes, i)
 function Base.similar(nodeset::NodeSet{Dim, RealT}) where {Dim, RealT}
-    return NodeSet{Dim, RealT}(similar(nodeset.nodes), Inf)
+    return NodeSet{Dim, RealT}(similar(nodeset.nodes), convert(RealT, NaN))
 end
 function Base.similar(nodeset::NodeSet{Dim, RealT}, ::Type{T}) where {Dim, RealT, T}
-    return NodeSet{Dim, T}(similar(nodeset.nodes, MVector{Dim, T}), Inf)
+    return NodeSet{Dim, T}(similar(nodeset.nodes, MVector{Dim, T}), convert(T, NaN))
 end
 function Base.similar(nodeset::NodeSet{Dim, RealT}, n::Int) where {Dim, RealT}
-    return NodeSet{Dim, RealT}(similar(nodeset.nodes, n), Inf)
+    return NodeSet{Dim, RealT}(similar(nodeset.nodes, n), convert(RealT, NaN))
 end
 function Base.similar(nodeset::NodeSet{Dim, RealT}, ::Type{T}, n::Int) where {Dim, RealT, T}
-    return NodeSet{Dim, T}(similar(nodeset.nodes, MVector{Dim, T}, n), Inf)
+    return NodeSet{Dim, T}(similar(nodeset.nodes, MVector{Dim, T}, n), convert(T, NaN))
 end
 Base.getindex(nodeset::NodeSet, i::Int) = nodeset.nodes[i]
 Base.getindex(nodeset::NodeSet, is::AbstractVector) = nodeset.nodes[is]

--- a/src/nodes.jl
+++ b/src/nodes.jl
@@ -75,6 +75,28 @@ function empty_nodeset(Dim, RealT = Float64)
     return NodeSet{Dim, RealT}(Vector{MVector{Dim, RealT}}[], convert(RealT, NaN))
 end
 
+"""
+    nearest_node_index(y, nodeset)
+
+Return the index of the node in `nodeset` that is closest to `y` in Euclidean norm.
+"""
+function nearest_node_index(y::AbstractVector, nodeset::NodeSet)
+    n = length(nodeset)
+    n > 0 || throw(ArgumentError("nodeset must be non-empty"))
+
+    best_idx = 1
+    best_dist = norm(y .- nodeset[1])
+    for i in 2:n
+        d = norm(y .- nodeset[i])
+        if d < best_dist
+            best_dist = d
+            best_idx = i
+        end
+    end
+
+    return best_idx
+end
+
 function separation_distance(nodes::Vector{MVector{Dim, RealT}}) where {Dim, RealT}
     length(nodes) < 2 && return convert(RealT, Inf)
     tree = KDTree(nodes)
@@ -85,6 +107,9 @@ function separation_distance(nodes::Vector{MVector{Dim, RealT}}) where {Dim, Rea
     return convert(RealT, 0.5 * minimum(d -> d[2], distances))
 end
 
+# The separation distance is computed lazily and cached in `nodeset.q`, with `NaN` marking a
+# stale/not-yet-computed value. It is (re)computed on first access after construction or a
+# mutation, and only when all nodes are assigned (to prevent `UndefRefError`).
 @doc raw"""
     separation_distance(nodeset::NodeSet)
 
@@ -93,9 +118,6 @@ Return the separation distance of a [`NodeSet`](@ref) ``X = \{x_1,\ldots, x_n\}`
     q_X = \frac{1}{2}\min_{x_i\neq x_j}\|x_i - x_j\|.
 ```
 """
-# The separation distance is computed lazily and cached in `nodeset.q`, with `NaN` marking a
-# stale/not-yet-computed value. It is (re)computed on first access after construction or a
-# mutation, and only when all nodes are assigned (to prevent `UndefRefError`).
 function separation_distance(nodeset::NodeSet)
     if isnan(nodeset.q) && all(i -> isassigned(nodeset, i), eachindex(nodeset))
         nodeset.q = separation_distance(nodeset.nodes)
@@ -241,7 +263,7 @@ The result is an approximation on the true fill distance
 ```math
     h_{X,\Omega} = \sup_{x \in \Omega}\,\min_{x_j \in X} \|x - x_j\|;
 ```
-accuracy improves with the density of `reference`. 
+accuracy improves with the density of `reference`.
 
 See also [`separation_distance`](@ref), [`distance_matrix`](@ref).
 """

--- a/src/rbf_fd/rbf_fd_basis.jl
+++ b/src/rbf_fd/rbf_fd_basis.jl
@@ -126,17 +126,31 @@ local_order(basis::RBFFDBasis) = maximum(degree.(basis.ps), init = -1) + 1
 _local_polynomial_basis(::RBFFDStandardBasis, xx, m::Int) = monomials(xx, 0:(m - 1))
 _local_polynomial_basis(::RBFFDLagrangeBasis, xx, m::Int) = monomials(xx, 0:-1)
 
+# Apply `f` to each element of `xs` in order, threaded over elements. The per-stencil caches
+# below are built from independent local problems, so they are assembled in parallel.
+function _tmap(f, xs)
+    n = length(xs)
+    n == 0 && return [f(x) for x in xs]
+    first_result = f(xs[1])
+    results = Vector{typeof(first_result)}(undef, n)
+    results[1] = first_result
+    Threads.@threads for i in 2:n
+        results[i] = f(xs[i])
+    end
+    return results
+end
+
 # RBFFDLagrangeBasis: cache the Lagrange cardinal functions on each stencil.
 function _build_local_cache(::RBFFDLagrangeBasis, kernel::AbstractKernel,
                             neighbor_nodesets, ps, m::Int)
-    return [collect(LagrangeBasis(nodes, kernel; m)) for nodes in neighbor_nodesets]
+    return _tmap(nodes -> collect(LagrangeBasis(nodes, kernel; m)), neighbor_nodesets)
 end
 
 # RBFFDStandardBasis: cache the factorization of each stencil's augmented system matrix
 # `M = [A P; P' 0]`, reused for every right-hand side (weights and evaluation).
 function _build_local_cache(::RBFFDStandardBasis, kernel::AbstractKernel,
                             neighbor_nodesets, ps, m::Int)
-    return [_local_factorization(kernel, nodes, ps) for nodes in neighbor_nodesets]
+    return _tmap(nodes -> _local_factorization(kernel, nodes, ps), neighbor_nodesets)
 end
 
 function _local_factorization(kernel::AbstractKernel, neighbor_nodes::NodeSet, ps)

--- a/src/rbf_fd/rbf_fd_matrices.jl
+++ b/src/rbf_fd/rbf_fd_matrices.jl
@@ -12,10 +12,13 @@ function _rbf_fd_sparse_matrix(op, basis::RBFFDBasis, nodeset::NodeSet)
     stencils = basis.stencil_indices
 
     # Each evaluation node uses the stencil of its nearest center, and the rows are mutually
-    # independent. Find the nearest center for every node first (threaded).
-    nearest = Vector{Int}(undef, n)
-    Threads.@threads for j in 1:n
-        nearest[j] = nearest_node_index(nodeset[j], X)
+    # independent. When the evaluation nodes are the centers themselves, the nearest center is
+    # the node itself; otherwise locate the nearest center for all nodes with a single KDTree
+    # query (O(n log N) instead of a brute-force O(n * N) scan).
+    if nodeset === X
+        nearest = collect(1:n)
+    else
+        nearest, _ = nn(KDTree(X.nodes), nodeset.nodes)
     end
 
     # Preallocate the COO buffers: each row contributes as many nonzeros as its stencil has

--- a/src/rbf_fd/rbf_fd_matrices.jl
+++ b/src/rbf_fd/rbf_fd_matrices.jl
@@ -8,22 +8,37 @@
 function _rbf_fd_sparse_matrix(op, basis::RBFFDBasis, nodeset::NodeSet)
     n = length(nodeset)
     m = length(basis)
-    rows = Int[]
-    cols = Int[]
-    vals = eltype(nodeset)[]
     X = centers(basis)
+    stencils = basis.stencil_indices
 
-    for j in 1:n
-        y_j = nodeset[j]
-        i = nearest_node_index(y_j, X)
-        w = local_weights(basis, i, y_j, op)
+    # Each evaluation node uses the stencil of its nearest center, and the rows are mutually
+    # independent. Find the nearest center for every node first (threaded).
+    nearest = Vector{Int}(undef, n)
+    Threads.@threads for j in 1:n
+        nearest[j] = nearest_node_index(nodeset[j], X)
+    end
+
+    # Preallocate the COO buffers: each row contributes as many nonzeros as its stencil has
+    # entries, and the prefix sums give every row a disjoint block to fill in parallel.
+    row_nnz = [length(stencils[nearest[j]]) for j in 1:n]
+    row_start = cumsum(row_nnz) .- row_nnz # 0-based start offset of each row's block
+    total = isempty(row_nnz) ? 0 : row_start[n] + row_nnz[n]
+    rows = Vector{Int}(undef, total)
+    cols = Vector{Int}(undef, total)
+    vals = Vector{eltype(nodeset)}(undef, total)
+
+    Threads.@threads for j in 1:n
+        i = nearest[j]
+        w = local_weights(basis, i, nodeset[j], op)
         w isa AbstractVector ||
             throw(ArgumentError("RBF-FD matrix assembly expects scalar operator values"))
-        indices = basis.stencil_indices[i]
+        indices = stencils[i]
+        base = row_start[j]
         for k in eachindex(indices)
-            push!(rows, j)
-            push!(cols, indices[k])
-            push!(vals, w[k])
+            p = base + k
+            rows[p] = j
+            cols[p] = indices[k]
+            vals[p] = w[k]
         end
     end
 


### PR DESCRIPTION
Improve performance by
- preallocating
- using threaded loops
- making `rhs!` allocation-free
- using `nn(KDTree(...), ...)` instead of the brute force `nearest_node_index`
- computing the `separation_distance` of a `NodeSet` lazily instead of each time