### PR TITLE
Revert workaround related to Coveralls on MacOS

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -73,10 +73,6 @@ jobs:
           files: lcov.info
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      # Workaround for https://github.com/coverallsapp/github-action/issues/264
-      - name: Trust Coveralls Homebrew tap (Homebrew 6 requirement)
-        if: runner.os == 'macOS'
-        run: brew trust coverallsapp/coveralls
       - uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This should not be needed more since the issues was fixed in the coveralls action.